### PR TITLE
🔥 Removed the global keyword

### DIFF
--- a/pincer/client.py
+++ b/pincer/client.py
@@ -77,7 +77,6 @@ class Client(Dispatcher):
                 0: self.event_handler
             }
         )
-        global _events
 
         # TODO: close the client after use
         self.http = HTTPClient(token, version=GatewayConfig.version)
@@ -87,7 +86,6 @@ class Client(Dispatcher):
     @staticmethod
     def event(coroutine: Coro):
         # TODO: Write docs
-        global _events
 
         if not iscoroutinefunction(coroutine):
             raise TypeError(


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `adds`: ...
-   `fixed`: ...
-   `improvements`: Removed `global` calls, since the referenced variable was a global variable & a mutable object, hence the `global` keyword had no effect on it.

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
