### PR TITLE
🎨 Fixed imports & types

### DIFF
--- a/pincer/objects/integration.py
+++ b/pincer/objects/integration.py
@@ -23,7 +23,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from dataclasses import dataclass
-from datetime import datetime
 from enum import Enum
 from typing import Optional
 

--- a/pincer/objects/integration.py
+++ b/pincer/objects/integration.py
@@ -31,6 +31,7 @@ from pincer.objects.user import User
 from pincer.utils.api_object import APIObject
 from pincer.utils.constants import MISSING, APINullable
 from pincer.utils.snowflake import Snowflake
+from pincer.utils.timestamp import Timestamp
 
 
 class IntegrationExpireBehavior(Enum):
@@ -149,16 +150,7 @@ class Integration(APIObject):
     expire_behavior: APINullable[IntegrationExpireBehavior] = MISSING
     expire_grace_period: APINullable[int] = MISSING
     user: APINullable[User] = MISSING
-    synced_at: APINullable[str] = MISSING
+    synced_at: APINullable[Timestamp] = MISSING
     subscriber_count: APINullable[int] = MISSING
     revoked: APINullable[bool] = MISSING
     application: APINullable[IntegrationApplication] = MISSING
-
-    def set_synced_at(self, time: datetime):
-        """
-        Set the synced time of the integration.
-
-        :param time:
-            The new time for the integration to be synced.
-        """
-        self.synced_at = time.isoformat()

--- a/pincer/objects/interactions.py
+++ b/pincer/objects/interactions.py
@@ -30,6 +30,7 @@ from pincer.objects.application_command import \
     ApplicationCommandInteractionDataOption
 from pincer.objects.channel import Channel
 from pincer.objects.guild_member import GuildMember
+from pincer.objects.message import Message
 from pincer.objects.role import Role
 from pincer.objects.select_menu import SelectOption
 from pincer.objects.user import User
@@ -81,8 +82,7 @@ class ResolvedData(APIObject):
     members: APINullable[Dict[Snowflake, GuildMember]] = MISSING
     roles: APINullable[Dict[Snowflake, Role]] = MISSING
     channels: APINullable[Dict[Snowflake, Channel]] = MISSING
-    messages: APINullable[Dict[Snowflake, ...]] = MISSING
-    # Message
+    messages: APINullable[Dict[Snowflake, Message]] = MISSING
 
 
 @dataclass
@@ -197,4 +197,4 @@ class Interaction(APIObject):
     channel_id: APINullable[Snowflake] = MISSING
     member: APINullable[GuildMember] = MISSING
     user: APINullable[User] = MISSING
-    message: APINullable[...] = MISSING  # Message
+    message: APINullable[Message] = MISSING

--- a/pincer/objects/message.py
+++ b/pincer/objects/message.py
@@ -125,11 +125,10 @@ class MessageType(Enum):
     GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING = 16
     GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING = 17
     THREAD_CREATED = 18
+    REPLY = 19
+    APPLICATION_COMMAND = 20
 
-    if GatewayConfig.version >= 8:
-        REPLY = 19
-        APPLICATION_COMMAND = 20
-    else:
+    if GatewayConfig.version < 8:
         REPLY = 0
         APPLICATION_COMMAND = 0
 

--- a/pincer/objects/role.py
+++ b/pincer/objects/role.py
@@ -93,4 +93,4 @@ class Role(APIObject):
     permissions: str
     position: int
 
-    tags: APINullable[...] = MISSING
+    tags: APINullable[RoleTags] = MISSING

--- a/pincer/utils/timestamp.py
+++ b/pincer/utils/timestamp.py
@@ -76,12 +76,15 @@ class Timestamp:
 
         :param time:
             The time to be converted to a datetime object.
-            This can be one of these types: str, float, int
+            This can be one of these types: datetime, float, int, str
 
             If no parameter is passed it will return the current
             datetime.
         """
-        if isinstance(time, str):
+        if isinstance(time, datetime):
+            return time
+
+        elif isinstance(time, str):
             return Timestamp.string_to_datetime(time)
 
         elif isinstance(time, (int, float)):


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `adds`:
    - support for type `datetime` in `Timestamp.parse`
    - added missing Message types in `interactions.py`
    - added missing RoleTags type in `role.py`
-   `fixed`: 
-   `improvements`:
    - Removed unused `datetime` import from `integration.py`
    - Changed `str` to `Timestamp` for `Integration.synced_at`
    - Removed `Integration.set_synced_at` function
    - Refactored the version check in `message.py:MessageType`

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
