### PR TITLE
🐛 Changed `Client.__received` to `Client.received_message` because it…

### DIFF
--- a/pincer/client.py
+++ b/pincer/client.py
@@ -187,7 +187,7 @@ class Client(Dispatcher):
         )
 
         self.bot: Optional[User] = None
-        self.__received = received or "Command arrived successfully!"
+        self.received_message = received or "Command arrived successfully!"
         self.http = HTTPClient(token)
 
     @property

--- a/pincer/middleware/interaction_create.py
+++ b/pincer/middleware/interaction_create.py
@@ -62,7 +62,7 @@ async def interaction_create_middleware(self, payload: GatewayDispatch):
             message = Message(embeds=[message])
         elif not isinstance(message, Message):
             message = Message(message) if message else Message(
-                self.__received,
+                self.received_message,
                 flags=InteractionFlags.EPHEMERAL
             )
 


### PR DESCRIPTION
… was causing issues

<!-- Please complete the missing ... parts. -->

### Changes

-   `fixed`: A bug

```py
Traceback (most recent call last):
  File "Pincer/pincer/client.py", line 350, in event_handler
    key, args, kwargs = await self.handle_middleware(payload, event_name)
  File "Pincer/pincer/client.py", line 313, in handle_middleware
    extractable = await ware(self, payload, *args, **kwargs)
  File "pincer/client.py", line 140, in wrapper
    return await (
  File "Pincer/pincer/middleware/interaction_create.py", line 65, in interaction_create_middleware
    self.__received,
AttributeError: 'Bot' object has no attribute '__received'
```

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
