### PR TITLE
Yieldable commands

### DIFF
--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 from asyncio import iscoroutinefunction
-from inspect import Signature
+from inspect import Signature, isasyncgenfunction
 from typing import Optional, Dict, List, Any, Tuple, get_origin, get_args, Union
 
 from . import __package__
@@ -62,7 +62,7 @@ def command(
 ):
     # TODO: Fix docs
     def decorator(func: Coro):
-        if not iscoroutinefunction(func):
+        if not iscoroutinefunction(func) and not isasyncgenfunction(func):
             raise CommandIsNotCoroutine(
                 f"Command with call `{func.__name__}` is not a coroutine, "
                 "which is required for commands."

--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -206,6 +206,7 @@ class HTTPClient:
             )
 
             exception.__init__(res.reason)
+            exception.json = await res.json()
             raise exception
 
         # status code is guaranteed to be 5xx


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `adds`: 
     - Ability to have commands with `yield` (sends a webhook to respond). [see API docs for implementation](https://discord.com/developers/docs/interactions/receiving-and-responding#followup-messages)
     - When creating the command, it checks if it is coroutine or asyncgenerator
     - API Exception includes a JSON property to see the response when using try-except. (this is taken advantage of in this pr)
     - A separate function to convert a message to a `Message` object

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
