### PR TITLE
Implements command choices

### DIFF
--- a/docs/PYPI.md
+++ b/docs/PYPI.md
@@ -81,7 +81,10 @@ following:
 - Http Client
 - Events
 - Event middleware
-- Basic commands with basic argument parsing
+- Commands
+- Command arguments *(for types: str, int, float, bool)*
+- Command argument choices
+- Command argument descriptions
 - Command cool downs (Using WindowSliding technique)
 
 **Client base class example:**

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,10 @@ following:
 - Http Client
 - Events
 - Event middleware
-- Basic commands with basic argument parsing
+- Commands
+- Command arguments *(for types: str, int, float, bool)*
+- Command argument choices
+- Command argument descriptions
 - Command cool downs (Using WindowSliding technique)
 
 **Client base class example:**

--- a/pincer/__init__.py
+++ b/pincer/__init__.py
@@ -20,6 +20,7 @@ __author__ = "Sigmanificient, Arthurdw"
 __email__ = "contact@pincer.org"
 __license__ = "MIT"
 
+from pincer.utils import Choices
 
 ReleaseType = Optional[Literal["alpha", "beta", "candidate", "final", "dev"]]
 
@@ -46,5 +47,5 @@ class VersionInfo(NamedTuple):
 __version__ = VersionInfo(0, 7, 1)
 __all__ = (
     "__author__", "__email__", "__package__", "__title__",  "__version__",
-    "Bot", "Client", "command", "Intents"
+    "Bot", "Client", "command", "Intents", "Choices"
 )

--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -110,6 +110,17 @@ def command(
             argument_description: Optional[str] = None
             choices: List[AppCommandOptionChoice] = []
 
+            if isinstance(annotation, tuple):
+                if len(annotation) != 2:
+                    raise InvalidArgumentAnnotation(
+                        f"Tuple annotation `{annotation}` on parameter "
+                        f"`{param}` in command `{cmd}` (`{func.__name__}`) "
+                        "does not consist of two elements. Please follow the "
+                        "correct format where the first element is the type"
+                        " and the second element is the description."
+                    )
+                annotation, argument_description = annotation
+
             if get_origin(annotation) is Union:
                 args = get_args(annotation)
                 if type(None) in args:
@@ -125,17 +136,6 @@ def command(
                     if len(union_args) == 1
                     else Union[Tuple[List]]
                 )
-
-            if isinstance(annotation, tuple):
-                if len(annotation) != 2:
-                    raise InvalidArgumentAnnotation(
-                        f"Tuple annotation `{annotation}` on parameter "
-                        f"`{param}` in command `{cmd}` (`{func.__name__}`) "
-                        "does not consist of two elements. Please follow the "
-                        "correct format where the first element is the type"
-                        " and the second element is the description."
-                    )
-                annotation, argument_description = annotation
 
             if get_origin(annotation) is Choices:
                 args = get_args(annotation)

--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -121,6 +121,14 @@ def command(
                     )
                 annotation, argument_description = annotation
 
+                if len(argument_description) > 100:
+                    raise CommandDescriptionTooLong(
+                        f"Tuple annotation `{annotation}` on parameter "
+                        f"`{param}` in command `{cmd}` (`{func.__name__}`), "
+                        "argument description too long. (maximum length is 100 "
+                        "characters)"
+                    )
+
             if get_origin(annotation) is Union:
                 args = get_args(annotation)
                 if type(None) in args:

--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -35,7 +35,7 @@ _options_type_link = {
     str: AppCommandOptionType.STRING,
     int: AppCommandOptionType.INTEGER,
     bool: AppCommandOptionType.BOOLEAN,
-    float: AppCommandOptionType.NUMBER,
+    float: AppCommandOptionType.NUMBER
 }
 
 

--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -18,11 +18,11 @@ from .exceptions import (
 from .objects import ThrottleScope
 from .objects.app_command import (
     AppCommand, AppCommandType, ClientCommandStructure,
-    AppCommandOption, AppCommandOptionType
+    AppCommandOption, AppCommandOptionType, AppCommandOptionChoice
 )
 from .utils import (
     get_signature_and_params, get_index, should_pass_ctx, Coro, Snowflake,
-    MISSING
+    MISSING, choice_value_types, Choices
 )
 
 COMMAND_NAME_REGEX = re.compile(r"^[\w-]{1,32}$")
@@ -35,7 +35,7 @@ _options_type_link = {
     str: AppCommandOptionType.STRING,
     int: AppCommandOptionType.INTEGER,
     bool: AppCommandOptionType.BOOLEAN,
-    float: AppCommandOptionType.NUMBER
+    float: AppCommandOptionType.NUMBER,
 }
 
 
@@ -49,6 +49,11 @@ def command(
         cooldown_scope: Optional[ThrottleScope] = ThrottleScope.USER
 ):
     # TODO: Fix docs
+    # TODO: Fix docs w guild
+    # TODO: Fix docs w cooldown
+    # TODO: Fix docs w context
+    # TODO: Fix docs w argument descriptions
+    # TODO: Fix docs w argument choices
     def decorator(func: Coro):
         if not iscoroutinefunction(func) and not isasyncgenfunction(func):
             raise CommandIsNotCoroutine(
@@ -103,6 +108,7 @@ def command(
 
             annotation, required = sig[param].annotation, True
             argument_description: Optional[str] = None
+            choices: List[AppCommandOptionChoice] = []
 
             if get_origin(annotation) is Union:
                 args = get_args(annotation)
@@ -131,6 +137,66 @@ def command(
                     )
                 annotation, argument_description = annotation
 
+            if get_origin(annotation) is Choices:
+                args = get_args(annotation)
+
+                if len(args) > 25:
+                    raise InvalidArgumentAnnotation(
+                        f"Choices/Literal annotation `{annotation}` on "
+                        f"parameter `{param}` in command `{cmd}` "
+                        f"(`{func.__name__}`) amount exceeds limit of 25 items!"
+                    )
+
+                choice_type = type(args[0])
+
+                for choice in args:
+                    choice_name = choice
+
+                    if isinstance(choice, tuple):
+                        if len(choice) != 2:
+                            raise InvalidArgumentAnnotation(
+                                f"Choices/Literal annotation `{annotation}` on "
+                                f"parameter `{param}` in command `{cmd}` "
+                                f"(`{func.__name__}`), specific choice "
+                                "declaration through tuple's must consist of "
+                                "2 items. First value is the name and the "
+                                "second value is the value."
+                            )
+
+                        choice_name, choice = str(choice[0]), choice[1]
+
+                        if choice_type is tuple:
+                            choice_type = type(choice)
+
+                    if type(choice) not in choice_value_types:
+                        # Properly get all the names of the types
+                        valid_types = list(map(
+                            lambda x: x.__name__,
+                            choice_value_types
+                        ))
+                        raise InvalidArgumentAnnotation(
+                            f"Choices/Literal annotation `{annotation}` on "
+                            f"parameter `{param}` in command `{cmd}` "
+                            f"(`{func.__name__}`), invalid type received. "
+                            "Value must be a member of "
+                            f"{', '.join(valid_types)} but "
+                            f"{type(choice).__name__} was given!"
+                        )
+                    elif not isinstance(choice, choice_type):
+                        raise InvalidArgumentAnnotation(
+                            f"Choices/Literal annotation `{annotation}` on "
+                            f"parameter `{param}` in command `{cmd}` "
+                            f"(`{func.__name__}`), all values must be of the "
+                            "same type!"
+                        )
+
+                    choices.append(AppCommandOptionChoice(
+                        name=choice_name,
+                        value=choice
+                    ))
+
+                annotation = choice_type
+
             param_type = _options_type_link.get(annotation)
             if not param_type:
                 raise InvalidArgumentAnnotation(
@@ -144,7 +210,8 @@ def command(
                     type=param_type,
                     name=param,
                     description=argument_description or "Description not set",
-                    required=required
+                    required=required,
+                    choices=choices or MISSING
                 )
             )
 

--- a/pincer/objects/app_command.py
+++ b/pincer/objects/app_command.py
@@ -15,7 +15,7 @@ from ..utils.snowflake import Snowflake
 
 if TYPE_CHECKING:
     from .throttle_scope import ThrottleScope
-    from ..utils.types import APINullable, Coro
+    from ..utils.types import APINullable, Coro, choice_value_types
 
 
 class AppCommandType(IntEnum):
@@ -129,7 +129,7 @@ class AppCommandOptionChoice(APIObject):
         value of the choice, up to 100 characters if string
     """
     name: str
-    value: Union[str, int, float]
+    value: Union[choice_value_types]
 
 
 @dataclass

--- a/pincer/utils/__init__.py
+++ b/pincer/utils/__init__.py
@@ -7,11 +7,11 @@ from .extraction import get_index, get_signature_and_params
 from .insertion import should_pass_cls, should_pass_ctx
 from .snowflake import Snowflake
 from .timestamp import Timestamp
-from .types import APINullable, Coro, MISSING
-
+from .types import APINullable, Coro, MISSING, Choices, choice_value_types
 
 __all__ = (
     "APINullable", "APIObject", "convert", "Coro", "get_index",
     "get_signature_and_params", "MISSING", "should_pass_cls",
-    "should_pass_ctx", "Snowflake", "Timestamp"
+    "should_pass_ctx", "Snowflake", "Timestamp", "Choices",
+    "choice_value_types"
 )

--- a/pincer/utils/types.py
+++ b/pincer/utils/types.py
@@ -1,7 +1,7 @@
 # Copyright Pincer 2021-Present
 # Full MIT License can be found in `LICENSE` at the project root.
 
-from typing import TypeVar, Callable, Coroutine, Any, Union
+from typing import TypeVar, Callable, Coroutine, Any, Union, Literal
 
 
 class MissingType:
@@ -18,3 +18,7 @@ APINullable = Union[T, MissingType]
 
 # Represents a coroutine.
 Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
+
+Choices = Literal
+
+choice_value_types = (str, int, float)


### PR DESCRIPTION
## Implements

Implements command argument choices.

## Example

You can add choices to arguments through the `pincer.Choices` *(which is an alias for `typing.Literal`)*.
Choice values must consist of the same type, and there can only be a maximum of 25 choices.

```py
@command()
async def choose(self, choice: Choices["Test", "Sample lol", "Geheh"]):
    return f"You chose: `{choice}`"
```

![image](https://user-images.githubusercontent.com/38541241/135713052-a9d99870-3212-4b7a-8932-894a91e1a921.png)

### Example with custom name/value

You can manually override the default name (which is set to the value) of a choice.
This is done through a tuple, where the first value is the choice name and the second one is the value. These can be combined with default choices. *(so no tuple, as seen in the example)*

```py
@command()
async def choose(
        self,
        choice: Choices[
            ("This will be the test value", "Test"),
            "Sample lol",
            "Geheh"
        ]
):
    return f"You chose: `{choice}`"
 ```
 
![image](https://user-images.githubusercontent.com/38541241/135712995-d3663703-91be-4c8e-a5cf-e858484a2df8.png)

*(So when `This will be the test value` is selected the bot will return `You chose: 'Test'`)*

