### PR TITLE
🔧 Changed `end_of_line` to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = false


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `fixed`: `end_of_line` in `.editorconfig` changed from CRLF to LF.

 ### Check off the following

-   [x] I have tested my changes with the current requirements
