### PR TITLE
Ignore line break before binary operator in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,9 @@ ignore =
     # H405: multi line docstring summary not separated with an empty line
     H405,
     # H501: Do not use self.__dict__ for string formatting
-    H501
+    H501,
+    # W503: line break before binary operator
+    W503
 exclude =
     # No need to traverse our git directory
     .git,


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `fixed`: Ignore W503 warning in flake8 so that we aren't warning for line breaks both before and after binary operators, just after.

 ### Check off the following

-   [X] I have tested my changes with the current requirements
-   [X] My Code follows the pep8 code style.
