### PR TITLE
Allow cogs to be loaded by callable instead of filename

### DIFF
--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -311,6 +311,8 @@ def command(
             )
         )
 
+        func.__is_command__ = True
+
         _log.info(f"Registered command `{cmd}` to `{func.__name__}`.")
         return func
 

--- a/pincer/middleware/channel_create.py
+++ b/pincer/middleware/channel_create.py
@@ -2,6 +2,8 @@
 # Full MIT License can be found in `LICENSE` at the project root.
 
 """Sent when a channel is created/joined on the client."""
+from __future__ import annotations
+
 from ..core.dispatch import GatewayDispatch
 from ..objects import Channel
 from ..utils.conversion import construct_client_dict


### PR DESCRIPTION
Not sure if this is an appropriate way to solve the problem within the current framework or if there are other side effects that need to be considered, but here is my suggestion for how to allow cogs to be loaded directly by a callable instead of by filename. Instead of using path as key for managers, use an explicit name parameter that defaults to path if not given.

### Changes

-   `adds`: Allow cogs to be loaded by passing the setup directly instead of passing filename that contains the setup

 ### Check off the following

-   [ ] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
