### PR TITLE
:children_crossing: Allow non-parenthesised `@command` decorator

### DIFF
--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -7,7 +7,7 @@ from pincer.exceptions import TimeoutError
 
 class Bot(Client):
 
-    @command()
+    @command()  # note that the parenthesis are optional
     async def guess(self, ctx: MessageContext, biggest_number: int):
 
         await ctx.reply(f"Starting the guessing game! Pick a number between 0 and {biggest_number}.")

--- a/pincer/commands.py
+++ b/pincer/commands.py
@@ -7,22 +7,37 @@ import logging
 import re
 from asyncio import iscoroutinefunction, gather
 from copy import deepcopy
+from functools import partial
 from inspect import Signature, isasyncgenfunction
 from typing import TYPE_CHECKING, get_origin, get_args, Union, Tuple, List
 
 from . import __package__
 from .utils.snowflake import Snowflake
 from .exceptions import (
-    CommandIsNotCoroutine, CommandAlreadyRegistered, TooManyArguments,
-    InvalidArgumentAnnotation, CommandDescriptionTooLong, InvalidCommandGuild,
-    InvalidCommandName, ForbiddenError
+    CommandIsNotCoroutine,
+    CommandAlreadyRegistered,
+    TooManyArguments,
+    InvalidArgumentAnnotation,
+    CommandDescriptionTooLong,
+    InvalidCommandGuild,
+    InvalidCommandName,
+    ForbiddenError,
 )
 from .objects import (
-    ThrottleScope, AppCommand, Role, User, Channel, Guild, MessageContext
+    ThrottleScope,
+    AppCommand,
+    Role,
+    User,
+    Channel,
+    Guild,
+    MessageContext,
 )
 from .objects.app import (
-    AppCommandOptionType, AppCommandOption, AppCommandOptionChoice,
-    ClientCommandStructure, AppCommandType
+    AppCommandOptionType,
+    AppCommandOption,
+    AppCommandOptionChoice,
+    ClientCommandStructure,
+    AppCommandType,
 )
 from .utils import get_index, should_pass_ctx
 from .utils.signature import get_signature_and_params
@@ -43,7 +58,6 @@ _options_type_link = {
     int: AppCommandOptionType.INTEGER,
     bool: AppCommandOptionType.BOOLEAN,
     float: AppCommandOptionType.NUMBER,
-
     User: AppCommandOptionType.USER,
     Channel: AppCommandOptionType.CHANNEL,
     Role: AppCommandOptionType.ROLE,
@@ -54,13 +68,15 @@ if TYPE_CHECKING:
 
 
 def command(
+    func=None,
+    *,
     name: Optional[str] = None,
     description: Optional[str] = "Description not set",
     enable_default: Optional[bool] = True,
     guild: Union[Snowflake, int, str] = None,
     cooldown: Optional[int] = 0,
     cooldown_scale: Optional[float] = 60,
-    cooldown_scope: Optional[ThrottleScope] = ThrottleScope.USER
+    cooldown_scope: Optional[ThrottleScope] = ThrottleScope.USER,
 ):
     """A decorator to create a command to register and respond to
     with the discord API from a function.
@@ -139,192 +155,201 @@ def command(
         Annotations must consist of name and value
     """
     # noqa: E501
-
-    def decorator(func: Coro):
-        if not iscoroutinefunction(func) and not isasyncgenfunction(func):
-            raise CommandIsNotCoroutine(
-                f"Command with call `{func.__name__}` is not a coroutine, "
-                "which is required for commands."
-            )
-
-        cmd = name or func.__name__
-
-        if not re.match(COMMAND_NAME_REGEX, cmd):
-            raise InvalidCommandName(
-                f"Command `{cmd}` doesn't follow the name requirements."
-                "Ensure to match the following regex:"
-                f" {COMMAND_NAME_REGEX.pattern}"
-            )
-
-        try:
-            guild_id = Snowflake(guild) if guild else MISSING
-        except ValueError:
-            raise InvalidCommandGuild(
-                f"Command with call `{func.__name__}` its `guilds` parameter "
-                "contains a non valid guild id."
-            )
-
-        if len(description) > 100:
-            raise CommandDescriptionTooLong(
-                f"Command `{cmd}` (`{func.__name__}`) its description exceeds "
-                "the 100 character limit."
-            )
-
-        if reg := ChatCommandHandler.register.get(cmd):
-            raise CommandAlreadyRegistered(
-                f"Command `{cmd}` (`{func.__name__}`) has already been "
-                f"registered by `{reg.call.__name__}`."
-            )
-
-        sig, params = get_signature_and_params(func)
-        pass_context = should_pass_ctx(sig, params)
-
-        if len(params) > (25 + pass_context):
-            raise TooManyArguments(
-                f"Command `{cmd}` (`{func.__name__}`) can only have 25 "
-                f"arguments (excluding the context and self) yet {len(params)} "
-                "were provided!"
-            )
-
-        options: List[AppCommandOption] = []
-
-        for idx, param in enumerate(params):
-            if idx == 0 and pass_context:
-                continue
-
-            annotation, required = sig[param].annotation, True
-
-            # ctx is type MessageContext but should not be included in the
-            # slash command
-            if annotation == MessageContext:
-                return
-
-            argument_description: Optional[str] = None
-            choices: List[AppCommandOptionChoice] = []
-
-            if isinstance(annotation, str):
-                TypeCache()
-                annotation = eval(annotation, TypeCache.cache, globals())
-
-            if isinstance(annotation, Descripted):
-                argument_description = annotation.description
-                annotation = annotation.key
-
-                if len(argument_description) > 100:
-                    raise CommandDescriptionTooLong(
-                        f"Tuple annotation `{annotation}` on parameter "
-                        f"`{param}` in command `{cmd}` (`{func.__name__}`), "
-                        "argument description too long. (maximum length is 100 "
-                        "characters)"
-                    )
-
-            if get_origin(annotation) is Union:
-                args = get_args(annotation)
-                if type(None) in args:
-                    required = False
-
-                # Do NOT use isinstance as this is a comparison between
-                # two values of the type type and isinstance does NOT
-                # work here.
-                union_args = [t for t in args if t is not type(None)]
-
-                annotation = (
-                    get_index(union_args, 0)
-                    if len(union_args) == 1
-                    else Tuple[List]
-                )
-
-            if get_origin(annotation) is Choices:
-                args = get_args(annotation)
-
-                if len(args) > 25:
-                    raise InvalidArgumentAnnotation(
-                        f"Choices/Literal annotation `{annotation}` on "
-                        f"parameter `{param}` in command `{cmd}` "
-                        f"(`{func.__name__}`) amount exceeds limit of 25 items!"
-                    )
-
-                choice_type = type(args[0])
-
-                if choice_type is Descripted:
-                    choice_type = type(args[0].key)
-
-                for choice in args:
-                    choice_description = choice
-                    if isinstance(choice, Descripted):
-                        choice_description = choice.description
-                        choice = choice.key
-
-                        if choice_type is tuple:
-                            choice_type = type(choice)
-
-                    if type(choice) not in choice_value_types:
-                        # Properly get all the names of the types
-                        valid_types = list(map(
-                            lambda x: x.__name__,
-                            choice_value_types
-                        ))
-                        raise InvalidArgumentAnnotation(
-                            f"Choices/Literal annotation `{annotation}` on "
-                            f"parameter `{param}` in command `{cmd}` "
-                            f"(`{func.__name__}`), invalid type received. "
-                            "Value must be a member of "
-                            f"{', '.join(valid_types)} but "
-                            f"{type(choice).__name__} was given!"
-                        )
-                    elif not isinstance(choice, choice_type):
-                        raise InvalidArgumentAnnotation(
-                            f"Choices/Literal annotation `{annotation}` on "
-                            f"parameter `{param}` in command `{cmd}` "
-                            f"(`{func.__name__}`), all values must be of the "
-                            "same type!"
-                        )
-
-                    choices.append(AppCommandOptionChoice(
-                        name=choice_description,
-                        value=choice
-                    ))
-
-                annotation = choice_type
-
-            param_type = _options_type_link.get(annotation)
-
-            if not param_type:
-                raise InvalidArgumentAnnotation(
-                    f"Annotation `{annotation}` on parameter "
-                    f"`{param}` in command `{cmd}` (`{func.__name__}`) is not "
-                    "a valid type."
-                )
-
-            options.append(
-                AppCommandOption(
-                    type=param_type,
-                    name=param,
-                    description=argument_description or "Description not set",
-                    required=required,
-                    choices=choices or MISSING
-                )
-            )
-
-        ChatCommandHandler.register[cmd] = ClientCommandStructure(
-            call=func,
+    
+    if func is None:
+        return partial(
+            command,
+            name=name,
+            description=description,
+            enable_default=enable_default,
+            guild=guild,
             cooldown=cooldown,
             cooldown_scale=cooldown_scale,
             cooldown_scope=cooldown_scope,
-            app=AppCommand(
-                name=cmd,
-                description=description,
-                type=AppCommandType.CHAT_INPUT,
-                default_permission=enable_default,
-                options=options,
-                guild_id=guild_id
+        )
+
+    if not iscoroutinefunction(func) and not isasyncgenfunction(func):
+        raise CommandIsNotCoroutine(
+            f"Command with call `{func.__name__}` is not a coroutine, "
+            "which is required for commands."
+        )
+
+    cmd = name or func.__name__
+
+    if not re.match(COMMAND_NAME_REGEX, cmd):
+        raise InvalidCommandName(
+            f"Command `{cmd}` doesn't follow the name requirements."
+            "Ensure to match the following regex:"
+            f" {COMMAND_NAME_REGEX.pattern}"
+        )
+
+    try:
+        guild_id = Snowflake(guild) if guild else MISSING
+    except ValueError:
+        raise InvalidCommandGuild(
+            f"Command with call `{func.__name__}` its `guilds` parameter "
+            "contains a non valid guild id."
+        )
+
+    if len(description) > 100:
+        raise CommandDescriptionTooLong(
+            f"Command `{cmd}` (`{func.__name__}`) its description exceeds "
+            "the 100 character limit."
+        )
+
+    if reg := ChatCommandHandler.register.get(cmd):
+        raise CommandAlreadyRegistered(
+            f"Command `{cmd}` (`{func.__name__}`) has already been "
+            f"registered by `{reg.call.__name__}`."
+        )
+
+    sig, params = get_signature_and_params(func)
+    pass_context = should_pass_ctx(sig, params)
+
+    if len(params) > (25 + pass_context):
+        raise TooManyArguments(
+            f"Command `{cmd}` (`{func.__name__}`) can only have 25 "
+            f"arguments (excluding the context and self) yet {len(params)} "
+            "were provided!"
+        )
+
+    options: List[AppCommandOption] = []
+
+    for idx, param in enumerate(params):
+        if idx == 0 and pass_context:
+            continue
+
+        annotation, required = sig[param].annotation, True
+
+        # ctx is type MessageContext but should not be included in the
+        # slash command
+        if annotation == MessageContext:
+            return
+
+        argument_description: Optional[str] = None
+        choices: List[AppCommandOptionChoice] = []
+
+        if isinstance(annotation, str):
+            TypeCache()
+            annotation = eval(annotation, TypeCache.cache, globals())
+
+        if isinstance(annotation, Descripted):
+            argument_description = annotation.description
+            annotation = annotation.key
+
+            if len(argument_description) > 100:
+                raise CommandDescriptionTooLong(
+                    f"Tuple annotation `{annotation}` on parameter "
+                    f"`{param}` in command `{cmd}` (`{func.__name__}`), "
+                    "argument description too long. (maximum length is 100 "
+                    "characters)"
+                )
+
+        if get_origin(annotation) is Union:
+            args = get_args(annotation)
+            if type(None) in args:
+                required = False
+
+            # Do NOT use isinstance as this is a comparison between
+            # two values of the type type and isinstance does NOT
+            # work here.
+            union_args = [t for t in args if t is not type(None)]
+
+            annotation = (
+                get_index(union_args, 0)
+                if len(union_args) == 1
+                else Tuple[List]
+            )
+
+        if get_origin(annotation) is Choices:
+            args = get_args(annotation)
+
+            if len(args) > 25:
+                raise InvalidArgumentAnnotation(
+                    f"Choices/Literal annotation `{annotation}` on "
+                    f"parameter `{param}` in command `{cmd}` "
+                    f"(`{func.__name__}`) amount exceeds limit of 25 items!"
+                )
+
+            choice_type = type(args[0])
+
+            if choice_type is Descripted:
+                choice_type = type(args[0].key)
+
+            for choice in args:
+                choice_description = choice
+                if isinstance(choice, Descripted):
+                    choice_description = choice.description
+                    choice = choice.key
+
+                    if choice_type is tuple:
+                        choice_type = type(choice)
+
+                if type(choice) not in choice_value_types:
+                    # Properly get all the names of the types
+                    valid_types = list(
+                        map(lambda x: x.__name__, choice_value_types)
+                    )
+                    raise InvalidArgumentAnnotation(
+                        f"Choices/Literal annotation `{annotation}` on "
+                        f"parameter `{param}` in command `{cmd}` "
+                        f"(`{func.__name__}`), invalid type received. "
+                        "Value must be a member of "
+                        f"{', '.join(valid_types)} but "
+                        f"{type(choice).__name__} was given!"
+                    )
+                elif not isinstance(choice, choice_type):
+                    raise InvalidArgumentAnnotation(
+                        f"Choices/Literal annotation `{annotation}` on "
+                        f"parameter `{param}` in command `{cmd}` "
+                        f"(`{func.__name__}`), all values must be of the "
+                        "same type!"
+                    )
+
+                choices.append(
+                    AppCommandOptionChoice(
+                        name=choice_description, value=choice
+                    )
+                )
+
+            annotation = choice_type
+
+        param_type = _options_type_link.get(annotation)
+
+        if not param_type:
+            raise InvalidArgumentAnnotation(
+                f"Annotation `{annotation}` on parameter "
+                f"`{param}` in command `{cmd}` (`{func.__name__}`) is not "
+                "a valid type."
+            )
+
+        options.append(
+            AppCommandOption(
+                type=param_type,
+                name=param,
+                description=argument_description or "Description not set",
+                required=required,
+                choices=choices or MISSING,
             )
         )
 
-        _log.info(f"Registered command `{cmd}` to `{func.__name__}`.")
-        return func
+    ChatCommandHandler.register[cmd] = ClientCommandStructure(
+        call=func,
+        cooldown=cooldown,
+        cooldown_scale=cooldown_scale,
+        cooldown_scope=cooldown_scope,
+        app=AppCommand(
+            name=cmd,
+            description=description,
+            type=AppCommandType.CHAT_INPUT,
+            default_permission=enable_default,
+            options=options,
+            guild_id=guild_id,
+        ),
+    )
 
-    return decorator
+    _log.info(f"Registered command `{cmd}` to `{func.__name__}`.")
+    return func
 
 
 class ChatCommandHandler(metaclass=Singleton):
@@ -339,6 +364,7 @@ class ChatCommandHandler(metaclass=Singleton):
     register: Dict
         Dictionary of :class:`~objects.app.command.ClientCommandStructure`
     """
+
     managers: Dict[str, Any] = {}
     register: Dict[str, ClientCommandStructure] = {}
 
@@ -356,13 +382,13 @@ class ChatCommandHandler(metaclass=Singleton):
         self.client = client
         self._api_commands: List[AppCommand] = []
         logging.debug(
-            "%i commands registered.",
-            len(ChatCommandHandler.register.items())
+            "%i commands registered.", len(ChatCommandHandler.register.items())
         )
-        self.client.throttler.throttle = dict(map(
-            lambda cmd: (cmd.call, {}),
-            ChatCommandHandler.register.values()
-        ))
+        self.client.throttler.throttle = dict(
+            map(
+                lambda cmd: (cmd.call, {}), ChatCommandHandler.register.values()
+            )
+        )
 
         self.__prefix = f"applications/{self.client.bot.id}"
 
@@ -377,19 +403,24 @@ class ChatCommandHandler(metaclass=Singleton):
             List of commands.
         """
         # TODO: Update if discord adds bulk get guild commands
-        guild_commands = await gather(*map(
-            lambda guild: self.client.http.get(
-                self.__prefix + self.__get_guild.format(
-                    guild_id=guild.id if isinstance(guild, Guild) else guild
-                )
-            ),
-            self.client.guilds
-        ))
-        return list(map(
-            AppCommand.from_dict,
-            await self.client.http.get(self.__prefix + self.__get)
-            + [cmd for guild in guild_commands for cmd in guild]
-        ))
+        guild_commands = await gather(
+            *map(
+                lambda guild: self.client.http.get(
+                    self.__prefix
+                    + self.__get_guild.format(
+                        guild_id=guild.id if isinstance(guild, Guild) else guild
+                    )
+                ),
+                self.client.guilds,
+            )
+        )
+        return list(
+            map(
+                AppCommand.from_dict,
+                await self.client.http.get(self.__prefix + self.__get)
+                + [cmd for guild in guild_commands for cmd in guild],
+            )
+        )
 
     async def remove_command(self, cmd: AppCommand, keep=False):
         """|coro|
@@ -403,7 +434,7 @@ class ChatCommandHandler(metaclass=Singleton):
         keep : bool
             Whether the command should be removed from the ChatCommandHandler.
             Set to :data:`True` to keep the command.
-            |default| :data:`False` 
+            |default| :data:`False`
         """
         # TODO: Update if discord adds bulk delete commands
         remove_endpoint = self.__delete_guild if cmd.guild_id else self.__delete
@@ -416,10 +447,7 @@ class ChatCommandHandler(metaclass=Singleton):
             del ChatCommandHandler.register[cmd.name]
 
     async def remove_commands(
-            self,
-            commands: List[AppCommand],
-            /,
-            keep: List[AppCommand] = None
+        self, commands: List[AppCommand], /, keep: List[AppCommand] = None
     ):
         """|coro|
 
@@ -434,10 +462,14 @@ class ChatCommandHandler(metaclass=Singleton):
             ChatCommandHandler.
             |default| :data:`None`
         """
-        await gather(*list(map(
-            lambda cmd: self.remove_command(cmd, cmd in (keep or [])),
-            commands
-        )))
+        await gather(
+            *list(
+                map(
+                    lambda cmd: self.remove_command(cmd, cmd in (keep or [])),
+                    commands,
+                )
+            )
+        )
 
     async def update_command(self, cmd: AppCommand, changes: Dict[str, Any]):
         """|coro|
@@ -455,16 +487,14 @@ class ChatCommandHandler(metaclass=Singleton):
         update_endpoint = self.__update_guild if cmd.guild_id else self.__update
 
         await self.client.http.patch(
-            self.__prefix + update_endpoint.format(command=cmd),
-            data=changes
+            self.__prefix + update_endpoint.format(command=cmd), data=changes
         )
 
         for key, value in changes.items():
             setattr(ChatCommandHandler.register[cmd.name], key, value)
 
     async def update_commands(
-            self,
-            to_update: Dict[AppCommand, Dict[str, Any]]
+        self, to_update: Dict[AppCommand, Dict[str, Any]]
     ):
         """|coro|
 
@@ -475,10 +505,14 @@ class ChatCommandHandler(metaclass=Singleton):
         to_update : Dict[:class:`~objects.app.command.AppCommand`, Dict[:class:`str`, Any]]
             Dictionary of commands to changes where changes is a dictionary too
         """  # noqa: E501
-        await gather(*list(map(
-            lambda cmd: self.update_command(cmd[0], cmd[1]),
-            to_update.items()
-        )))
+        await gather(
+            *list(
+                map(
+                    lambda cmd: self.update_command(cmd[0], cmd[1]),
+                    to_update.items(),
+                )
+            )
+        )
 
     async def add_command(self, cmd: AppCommand):
         """|coro|
@@ -496,11 +530,10 @@ class ChatCommandHandler(metaclass=Singleton):
             add_endpoint = self.__add_guild.format(command=cmd)
 
         res = await self.client.http.post(
-            self.__prefix + add_endpoint,
-            data=cmd.to_dict()
+            self.__prefix + add_endpoint, data=cmd.to_dict()
         )
 
-        ChatCommandHandler.register[cmd.name].app.id = Snowflake(res['id'])
+        ChatCommandHandler.register[cmd.name].app.id = Snowflake(res["id"])
 
     async def add_commands(self, commands: List[AppCommand]):
         """|coro|
@@ -512,10 +545,7 @@ class ChatCommandHandler(metaclass=Singleton):
         commands : List[:class:`~pincer.objects.app.command.AppCommand`]
             List of command objects to add
         """
-        await gather(*list(map(
-            lambda cmd: self.add_command(cmd),
-            commands
-        )))
+        await gather(*list(map(lambda cmd: self.add_command(cmd), commands)))
 
     async def __init_existing_commands(self):
         """|coro|
@@ -526,9 +556,7 @@ class ChatCommandHandler(metaclass=Singleton):
             self._api_commands = await self.get_commands()
 
         except ForbiddenError:
-            logging.error(
-                "Cannot retrieve slash commands, skipping..."
-            )
+            logging.error("Cannot retrieve slash commands, skipping...")
 
             return
 
@@ -543,10 +571,12 @@ class ChatCommandHandler(metaclass=Singleton):
         Remove commands that are registered by discord but not in use
         by the current client
         """
-        registered_commands = list(map(
-            lambda registered_cmd: registered_cmd.app,
-            ChatCommandHandler.register.values()
-        ))
+        registered_commands = list(
+            map(
+                lambda registered_cmd: registered_cmd.app,
+                ChatCommandHandler.register.values(),
+            )
+        )
         keep = []
 
         def predicate(target: AppCommand) -> bool:
@@ -562,10 +592,9 @@ class ChatCommandHandler(metaclass=Singleton):
 
         await self.remove_commands(to_remove, keep=keep)
 
-        self._api_commands = list(filter(
-            lambda cmd: cmd not in to_remove,
-            self._api_commands
-        ))
+        self._api_commands = list(
+            filter(lambda cmd: cmd not in to_remove, self._api_commands)
+        )
 
     async def __update_existing_commands(self):
         """|coro|
@@ -575,10 +604,7 @@ class ChatCommandHandler(metaclass=Singleton):
         """
         to_update: Dict[AppCommand, Dict[str, Any]] = {}
 
-        def get_changes(
-                api: AppCommand,
-                local: AppCommand
-        ) -> Dict[str, Any]:
+        def get_changes(api: AppCommand, local: AppCommand) -> Dict[str, Any]:
             update: Dict[str, Any] = {}
 
             if api.description != local.description:
@@ -590,22 +616,29 @@ class ChatCommandHandler(metaclass=Singleton):
             options: List[Dict[str, Any]] = []
             if api.options is not MISSING:
                 if len(api.options) == len(local.options):
-                    def get_option(args: Tuple[int, Any]) \
-                            -> Optional[Dict[str, Any]]:
+
+                    def get_option(
+                        args: Tuple[int, Any]
+                    ) -> Optional[Dict[str, Any]]:
                         index, api_option = args
 
                         if opt := get_index(local.options, index):
                             return opt.to_dict()
 
-                    options = list(filter(
-                        lambda opt: opt is not None,
-                        map(get_option, enumerate(api.options))
-                    ))
+                    options = list(
+                        filter(
+                            lambda opt: opt is not None,
+                            map(get_option, enumerate(api.options)),
+                        )
+                    )
                 else:
                     options = local.options
 
-            if api.options is not MISSING and list(
-                    map(AppCommandOption.from_dict, options)) != api.options:
+            if (
+                api.options is not MISSING
+                and list(map(AppCommandOption.from_dict, options))
+                != api.options
+            ):
                 update["options"] = options
 
             return update
@@ -633,10 +666,9 @@ class ChatCommandHandler(metaclass=Singleton):
 
                 for key, change in changes.items():
                     if key == "options":
-                        self._api_commands[idx].options = list(map(
-                            AppCommandOption.from_dict,
-                            change
-                        ))
+                        self._api_commands[idx].options = list(
+                            map(AppCommandOption.from_dict, change)
+                        )
                     else:
                         setattr(self._api_commands[idx], key, change)
 
@@ -655,10 +687,7 @@ class ChatCommandHandler(metaclass=Singleton):
             except IndexError:
                 pass
 
-        await self.add_commands(list(map(
-            lambda cmd: cmd.app,
-            to_add.values()
-        )))
+        await self.add_commands(list(map(lambda cmd: cmd.app, to_add.values())))
 
     async def initialize(self):
         """|coro|


### PR DESCRIPTION
### Changes

```py
@command  # () is optional
async def test():
    return Message("Succes")
```

This simply allows for a non-parenthesised `@command` decorator

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
