### PR TITLE
:sparkles: Added role and ban related Guild methods

### DIFF
--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -524,7 +524,7 @@ class Guild(APIObject):
     ) -> Role:
         """|coro|
         Creates a new role for the guild.
-        Requires the `MANAGE_ROLES` permission.
+        Requires the ``MANAGE_ROLES`` permission.
 
         Parameters
         ----------
@@ -542,10 +542,10 @@ class Guild(APIObject):
             separately in the sidebar |default| :data:`False`
         icon : Optional[:class:`str`]
             the role's icon image (if the guild has
-            the `ROLE_ICONS` feature) |default| :data:`None`
+            the ``ROLE_ICONS`` feature) |default| :data:`None`
         unicode_emoji : Optional[:class:`str`]
             the role's unicode emoji as a standard emoji (if the guild
-            has the `ROLE_ICONS` feature) |default| :data:`None`
+            has the ``ROLE_ICONS`` feature) |default| :data:`None`
         mentionable : Optional[:class:`bool`]
             whether the role should be mentionable |default| :data:`False`
 
@@ -623,7 +623,7 @@ class Guild(APIObject):
     ) -> Role:
         """|coro|
         Edits a role.
-        Requires the `MANAGE_ROLES` permission.
+        Requires the ``MANAGE_ROLES`` permission.
 
         Parameters
         ----------
@@ -643,10 +643,10 @@ class Guild(APIObject):
             separately in the sidebar |default| :data:`None`
         icon : Optional[:class:`str`]
             The role's icon image (if the guild has
-            the `ROLE_ICONS` feature) |default| :data:`None`
+            the ``ROLE_ICONS`` feature) |default| :data:`None`
         unicode_emoji : Optional[:class:`str`]
             The role's unicode emoji as a standard emoji (if the guild
-            has the `ROLE_ICONS` feature) |default| :data:`None`
+            has the ``ROLE_ICONS`` feature) |default| :data:`None`
         mentionable : Optional[:class:`bool`]
             Whether the role should be mentionable |default| :data:`None`
 
@@ -680,7 +680,6 @@ class Guild(APIObject):
         """|coro|
         Deletes a role.
         Requires the `MANAGE_ROLES` permission.
-        Returns `204 No Content` on success.
 
         Parameters
         ----------
@@ -712,7 +711,6 @@ class Guild(APIObject):
     async def get_ban(self, id: Snowflake) -> Ban:
         """|coro|
         Fetches a ban from the guild.
-        Returns `404 Not Found` if the user is not banned.
 
         Parameters
         ----------
@@ -734,7 +732,6 @@ class Guild(APIObject):
     async def unban(self, id: Snowflake, reason: Optional[str] = None):
         """|coro|
         Unbans a user from the guild.
-        Returns `204 No Content` on success.
 
         Parameters
         ----------

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -506,8 +506,8 @@ class Guild(APIObject):
             An async generator of Role objects.
         """
         data = await self._http.get(f"guilds/{self.id}/roles")
-        for i in data:
-            yield Role.from_dict(construct_client_dict(self._client, i))
+        for role_data in data:
+            yield Role.from_dict(construct_client_dict(self._client, role_data))
 
     @overload
     async def create_role(
@@ -534,7 +534,8 @@ class Guild(APIObject):
             name of the role |default| :data:`"new role"`
         permissions : Optional[:class:`str`]
             bitwise value of the enabled/disabled
-            permissions |default| :data:`None`
+            permissions, set to @everyone permissions
+            by default |default| :data:`None`
         color : Optional[:class:`int`]
             RGB color value |default| :data:`0`
         hoist : Optional[:class:`bool`]
@@ -604,8 +605,8 @@ class Guild(APIObject):
             if reason is not None
             else {}
         )
-        for i in data:
-            yield Role.from_dict(construct_client_dict(self._client, i))
+        for role_data in data:
+            yield Role.from_dict(construct_client_dict(self._client, role_data))
 
     @overload
     async def edit_role(
@@ -705,8 +706,8 @@ class Guild(APIObject):
             An async generator of Ban objects.
         """
         data = await self._http.get(f"guilds/{self.id}/bans")
-        for i in data:
-            yield Ban.from_dict(construct_client_dict(self._client, i))
+        for ban_data in data:
+            yield Ban.from_dict(construct_client_dict(self._client, ban_data))
 
     async def get_ban(self, id: Snowflake) -> Ban:
         """|coro|

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -512,6 +512,7 @@ class Guild(APIObject):
     @overload
     async def create_role(
         self,
+        reason: Optional[str] = None,
         *,
         name: Optional[str] = "new role",
         permissions: Optional[str] = None,
@@ -527,24 +528,26 @@ class Guild(APIObject):
 
         Parameters
         ----------
+        reason : Optional[:class:`str`]
+            Reason for creating the role. |default| :data:`None`
         name : Optional[:class:`str`]
-            name of the role |default| data:`"new role"`
+            name of the role |default| :data:`"new role"`
         permissions : Optional[:class:`str`]
             bitwise value of the enabled/disabled
-            permissions |default| data:`None`
+            permissions |default| :data:`None`
         color : Optional[:class:`int`]
-            RGB color value |default| data:`0`
+            RGB color value |default| :data:`0`
         hoist : Optional[:class:`bool`]
             whether the role should be displayed
-            separately in the sidebar |default| data:`False`
+            separately in the sidebar |default| :data:`False`
         icon : Optional[:class:`str`]
             the role's icon image (if the guild has
-            the `ROLE_ICONS` feature) |default| data:`None`
+            the `ROLE_ICONS` feature) |default| :data:`None`
         unicode_emoji : Optional[:class:`str`]
             the role's unicode emoji as a standard emoji (if the guild
-            has the `ROLE_ICONS` feature) |default| data:`None`
+            has the `ROLE_ICONS` feature) |default| :data:`None`
         mentionable : Optional[:class:`bool`]
-            whether the role should be mentionable |default| data:`False`
+            whether the role should be mentionable |default| :data:`False`
 
         Returns
         -------
@@ -553,17 +556,28 @@ class Guild(APIObject):
         """
         ...
 
-    async def create_role(self, **kwargs) -> Role:
+    async def create_role(
+        self,
+        reason: Optional[str] = None,
+        **kwargs
+    ) -> Role:
         return Role.from_dict(
             construct_client_dict(
                 self._client,
-                await self._http.post(f"guilds/{self.id}/roles", data=kwargs),
+                await self._http.post(
+                    f"guilds/{self.id}/roles",
+                    data=kwargs,
+                    headers={"X-Audit-Log-Reason": reason}
+                    if reason is not None
+                    else {},
+                ),
             )
         )
 
     async def edit_role_position(
         self,
         id: Snowflake,
+        reason: Optional[str] = None,
         position: Optional[int] = None
     ) -> AsyncGenerator[Role, None]:
         """|coro|
@@ -573,8 +587,10 @@ class Guild(APIObject):
         ----------
         id : :class:`~pincer.utils.snowflake.Snowflake`
             The role ID
+        reason : Optional[:class:`str`]
+            Reason for editing the role position. |default| :data:`None`
         position : Optional[:class:`int`]
-            Sorting position of the role |default| data:`None`
+            Sorting position of the role |default| :data:`None`
 
         Returns
         -------
@@ -584,13 +600,18 @@ class Guild(APIObject):
         data = await self._http.patch(
             f"guilds/{self.id}/roles",
             data={"id": id, "position": position},
+            headers={"X-Audit-Log-Reason": reason}
+            if reason is not None
+            else {}
         )
         for i in data:
             yield Role.from_dict(construct_client_dict(self._client, i))
+
     @overload
     async def edit_role(
         self,
         id: Snowflake,
+        reason: Optional[str] = None,
         *,
         name: Optional[str] = None,
         permissions: Optional[str] = None,
@@ -608,24 +629,26 @@ class Guild(APIObject):
         ----------
         id : :class:`~pincer.utils.snowflake.Snowflake`
             The role ID
+        reason : Optional[:class:`str`]
+            Reason for editing the role |default| :data:`None`
         name : Optional[:class:`str`]
-            Name of the role |default| data:`None`
+            Name of the role |default| :data:`None`
         permissions : Optional[:class:`str`]
             Bitwise value of the enabled/disabled
-            permissions |default| data:`None`
+            permissions |default| :data:`None`
         color : Optional[:class:`int`]
-            RGB color value |default| data:`None`
+            RGB color value |default| :data:`None`
         hoist : Optional[:class:`bool`]
             Whether the role should be displayed
-            separately in the sidebar |default| data:`None`
+            separately in the sidebar |default| :data:`None`
         icon : Optional[:class:`str`]
             The role's icon image (if the guild has
-            the `ROLE_ICONS` feature) |default| data:`None`
+            the `ROLE_ICONS` feature) |default| :data:`None`
         unicode_emoji : Optional[:class:`str`]
             The role's unicode emoji as a standard emoji (if the guild
-            has the `ROLE_ICONS` feature) |default| data:`None`
+            has the `ROLE_ICONS` feature) |default| :data:`None`
         mentionable : Optional[:class:`bool`]
-            Whether the role should be mentionable |default| data:`None`
+            Whether the role should be mentionable |default| :data:`None`
 
         Returns
         -------
@@ -634,17 +657,26 @@ class Guild(APIObject):
         """
         ...
 
-    async def edit_role(self, id: Snowflake, **kwargs) -> Role:
+    async def edit_role(
+        self,
+        id: Snowflake,
+        reason: Optional[str] = None,
+        **kwargs
+    ) -> Role:
         return Role.from_dict(
             construct_client_dict(
                 self._client,
                 await self._http.patch(
-                    f"guilds/{self.id}/roles/{id}", data=kwargs
+                    f"guilds/{self.id}/roles/{id}",
+                    data=kwargs,
+                    headers={"X-Audit-Log-Reason": reason}
+                    if reason is not None
+                    else {},
                 ),
             )
         )
 
-    async def delete_role(self, id: Snowflake):
+    async def delete_role(self, id: Snowflake, reason: Optional[str] = None):
         """|coro|
         Deletes a role.
         Requires the `MANAGE_ROLES` permission.
@@ -654,8 +686,15 @@ class Guild(APIObject):
         ----------
         id : :class:`~pincer.utils.snowflake.Snowflake`
             The role ID
+        reason : Optional[:class:`str`]
+            The reason for deleting the role |default| :data:`None`
         """
-        await self._http.delete(f"guilds/{self.id}/roles/{id}")
+        await self._http.delete(
+            f"guilds/{self.id}/roles/{id}",
+            headers={"X-Audit-Log-Reason": reason}
+            if reason is not None
+            else {},
+        )
 
     async def get_bans(self) -> AsyncGenerator[Ban, None]:
         """|coro|
@@ -692,7 +731,7 @@ class Guild(APIObject):
             )
         )
 
-    async def unban(self, id: Snowflake):
+    async def unban(self, id: Snowflake, reason: Optional[str] = None):
         """|coro|
         Unbans a user from the guild.
         Returns `204 No Content` on success.
@@ -701,8 +740,15 @@ class Guild(APIObject):
         ----------
         id : :class:`~pincer.utils.snowflake.Snowflake`
             The user ID
+        reason : Optional[:class:`str`]
+            The reason for unbanning the user |default| :data:`None`
         """
-        await self._http.delete(f"guilds/{self.id}/bans/{id}")
+        await self._http.delete(
+            f"guilds/{self.id}/bans/{id}",
+            headers={"X-Audit-Log-Reason": reason}
+            if reason is not None
+            else {}
+        )
 
     @overload
     async def edit(

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -687,8 +687,6 @@ class Guild(APIObject):
             The user ID
         """
         await self._http.delete(f"guilds/{self.id}/bans/{id}")
-    
-    remove_ban = unban
 
     @overload
     async def edit(

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -45,6 +45,7 @@ class PremiumTier(IntEnum):
     TIER_3:
         Guild has unlocked Server Boost level 3 perks.
     """
+
     NONE = 0
     TIER_1 = 1
     TIER_2 = 2
@@ -64,6 +65,7 @@ class GuildNSFWLevel(IntEnum):
     AGE_RESTRICTED:
         Age restricted NSFW level.
     """
+
     DEFAULT = 0
     EXPLICIT = 1
     SAFE = 2
@@ -81,6 +83,7 @@ class ExplicitContentFilterLevel(IntEnum):
     ALL_MEMBERS:
         Media content sent by all members will be scanned.
     """
+
     DISABLED = 0
     MEMBERS_WITHOUT_ROLES = 1
     ALL_MEMBERS = 2
@@ -95,6 +98,7 @@ class MFALevel(IntEnum):
     ELEVATED:
         Guild has a 2FA requirement for moderation actions
     """
+
     NONE = 0
     ELEVATED = 1
 
@@ -114,6 +118,7 @@ class VerificationLevel(IntEnum):
     VERY_HIGH:
         Must have a verified phone number.
     """
+
     NONE = 0
     LOW = 1
     MEDIUM = 2
@@ -130,6 +135,7 @@ class DefaultMessageNotificationLevel(IntEnum):
     ONLY_MENTIONS:
         Members will receive notifications only for messages that @mention them by default.
     """
+
     # noqa: E501
     ALL_MESSAGES = 0
     ONLY_MENTIONS = 1
@@ -148,6 +154,7 @@ class SystemChannelFlags(IntEnum):
     SUPPRESS_JOIN_NOTIFICATION_REPLIES:
         Hide member join sticker reply buttons
     """
+
     SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0
     SUPPRESS_PREMIUM_SUBSCRIPTIONS = 1 << 1
     SUPPRESS_GUILD_REMINDER_NOTIFICATIONS = 1 << 2
@@ -180,6 +187,7 @@ class GuildPreview(APIObject):
     description: :class:`str`
         The guild description.
     """
+
     id: Snowflake
     name: str
     emojis: List[Emoji]
@@ -319,6 +327,7 @@ class Guild(APIObject):
         The welcome screen of a Community guild, shown to new members,
         returned in an Invite's guild object
     """
+
     # noqa: E501
     afk_timeout: int
     default_message_notifications: DefaultMessageNotificationLevel
@@ -426,13 +435,14 @@ class Guild(APIObject):
 
     @overload
     async def modify_member(
-            self, *,
-            _id: int,
-            nick: Optional[str] = None,
-            roles: Optional[List[Snowflake]] = None,
-            mute: Optional[bool] = None,
-            deaf: Optional[bool] = None,
-            channel_id: Optional[Snowflake] = None
+        self,
+        *,
+        _id: int,
+        nick: Optional[str] = None,
+        roles: Optional[List[Snowflake]] = None,
+        mute: Optional[bool] = None,
+        deaf: Optional[bool] = None,
+        channel_id: Optional[Snowflake] = None,
     ) -> GuildMember:
         """|coro|
         Modifies a member in the guild from its identifier and based on the
@@ -460,8 +470,7 @@ class Guild(APIObject):
 
     async def modify_member(self, _id: int, **kwargs) -> GuildMember:
         data = await self._http.patch(
-            f"guilds/{self.id}/members/{_id}",
-            data=kwargs
+            f"guilds/{self.id}/members/{_id}", data=kwargs
         )
         return GuildMember.from_dict(construct_client_dict(self._client, data))
 
@@ -497,7 +506,9 @@ class Guild(APIObject):
             A list of Role objects.
         """
         data = await self._http.get(f"guilds/{self.id}/roles")
-        return [Role.from_dict(construct_client_dict(self._client, i)) for i in data]
+        return [
+            Role.from_dict(construct_client_dict(self._client, i)) for i in data
+        ]
 
     @overload
     async def create_role(
@@ -509,7 +520,7 @@ class Guild(APIObject):
         hoist: Optional[bool] = False,
         icon: Optional[str] = None,
         unicode_emoji: Optional[str] = None,
-        mentionable: Optional[bool] = False
+        mentionable: Optional[bool] = False,
     ) -> Role:
         """|coro|
         Creates a new role for the guild.
@@ -544,7 +555,12 @@ class Guild(APIObject):
         ...
 
     async def create_role(self, **kwargs) -> Role:
-        return await self._http.post(f"guilds/{self.id}/roles", data=kwargs)
+        return Role.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(f"guilds/{self.id}/roles", data=kwargs),
+            )
+        )
 
     async def edit_role_position(
         self,
@@ -569,8 +585,7 @@ class Guild(APIObject):
         return [
             Role.from_dict(construct_client_dict(self._client, i))
             for i in await self._http.patch(
-                f"guilds/{self.id}/roles",
-                data={"id": id, "position": position}
+                f"guilds/{self.id}/roles", data={"id": id, "position": position}
             )
         ]
 
@@ -585,7 +600,7 @@ class Guild(APIObject):
         hoist: Optional[bool] = None,
         icon: Optional[str] = None,
         unicode_emoji: Optional[str] = None,
-        mentionable: Optional[bool] = None
+        mentionable: Optional[bool] = None,
     ) -> Role:
         """|coro|
         Edits a role.
@@ -625,7 +640,9 @@ class Guild(APIObject):
         return Role.from_dict(
             construct_client_dict(
                 self._client,
-                await self._http.patch(f"guilds/{self.id}/roles/{id}", data=kwargs)
+                await self._http.patch(
+                    f"guilds/{self.id}/roles/{id}", data=kwargs
+                ),
             )
         )
 
@@ -652,7 +669,9 @@ class Guild(APIObject):
             A list of Ban objects.
         """
         data = await self._http.get(f"guilds/{self.id}/bans")
-        return [Ban.from_dict(construct_client_dict(self._client, i)) for i in data]
+        return [
+            Ban.from_dict(construct_client_dict(self._client, i)) for i in data
+        ]
 
     async def get_ban(self, id: Snowflake) -> Ban:
         """|coro|
@@ -672,7 +691,7 @@ class Guild(APIObject):
         return Ban.from_dict(
             construct_client_dict(
                 self._client,
-                await self._http.get(f"guilds/{self.id}/bans/{id}")
+                await self._http.get(f"guilds/{self.id}/bans/{id}"),
             )
         )
 
@@ -710,7 +729,7 @@ class Guild(APIObject):
         public_updates_channel_id: Optional[Snowflake] = None,
         preferred_locale: Optional[str] = None,
         features: Optional[List[GuildFeature]] = None,
-        description: Optional[str] = None
+        description: Optional[str] = None,
     ) -> Guild:
         """|coro|
         Modifies the guild

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -486,7 +486,7 @@ class Guild(APIObject):
             ID of the guild member to kick.
         """
         await self._http.delete(f"guilds/{self.id}/members/{member_id}")
-    
+
     async def get_roles(self):
         """|coro|
         Fetches all the roles in the guild.
@@ -498,7 +498,7 @@ class Guild(APIObject):
         """
         data = await self._http.get(f"guilds/{self.id}/roles")
         return [Role.from_dict(construct_client_dict(self._client, i)) for i in data]
-    
+
     @overload
     async def create_role(
         self,
@@ -542,10 +542,10 @@ class Guild(APIObject):
             The new role object.
         """
         ...
-    
+
     async def create_role(self, **kwargs) -> Role:
         return await self._http.post(f"guilds/{self.id}/roles", data=kwargs)
-    
+
     async def edit_role_position(
         self,
         id: Snowflake,
@@ -613,14 +613,14 @@ class Guild(APIObject):
             has the `ROLE_ICONS` feature) |default| data:`None`
         mentionable : Optional[:class:`bool`]
             Whether the role should be mentionable |default| data:`None`
-        
+
         Returns
         -------
         :class:`~pincer.objects.guild.role.Role`
             The edited role object.
         """
         ...
-    
+
     async def edit_role(self, id: Snowflake, **kwargs) -> Role:
         return Role.from_dict(
             construct_client_dict(
@@ -628,7 +628,7 @@ class Guild(APIObject):
                 await self._http.patch(f"guilds/{self.id}/roles/{id}", data=kwargs)
             )
         )
-    
+
     async def delete_role(self, id: Snowflake):
         """|coro|
         Deletes a role.
@@ -641,7 +641,7 @@ class Guild(APIObject):
             The role ID
         """
         await self._http.delete(f"guilds/{self.id}/roles/{id}")
-    
+
     async def get_bans(self) -> List[Ban]:
         """|coro|
         Fetches all the bans in the guild.
@@ -653,7 +653,7 @@ class Guild(APIObject):
         """
         data = await self._http.get(f"guilds/{self.id}/bans")
         return [Ban.from_dict(construct_client_dict(self._client, i)) for i in data]
-    
+
     async def get_ban(self, id: Snowflake) -> Ban:
         """|coro|
         Fetches a ban from the guild.
@@ -675,7 +675,7 @@ class Guild(APIObject):
                 await self._http.get(f"guilds/{self.id}/bans/{id}")
             )
         )
-    
+
     async def unban(self, id: Snowflake):
         """|coro|
         Unbans a user from the guild.
@@ -779,6 +779,7 @@ class Guild(APIObject):
     async def preview(self) -> GuildPreview:
         """|coro|
         Previews the guild.
+
         Returns
         -------
         :class:`~pincer.objects.guild.guild.GuildPreview`

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import overload, TYPE_CHECKING
+from typing import AsyncGenerator, overload, TYPE_CHECKING
 
 from .ban import Ban
 from .channel import Channel
@@ -496,19 +496,18 @@ class Guild(APIObject):
         """
         await self._http.delete(f"guilds/{self.id}/members/{member_id}")
 
-    async def get_roles(self):
+    async def get_roles(self) -> AsyncGenerator[Role, None]:
         """|coro|
         Fetches all the roles in the guild.
 
         Returns
         -------
-        List[:class:`~pincer.objects.guild.role.Role`]
-            A list of Role objects.
+        AsyncGenerator[:class:`~pincer.objects.guild.role.Role`, :data:`None`]
+            An async generator of Role objects.
         """
         data = await self._http.get(f"guilds/{self.id}/roles")
-        return [
-            Role.from_dict(construct_client_dict(self._client, i)) for i in data
-        ]
+        for i in data:
+            yield Role.from_dict(construct_client_dict(self._client, i))
 
     @overload
     async def create_role(
@@ -566,7 +565,7 @@ class Guild(APIObject):
         self,
         id: Snowflake,
         position: Optional[int] = None
-    ) -> List[Role]:
+    ) -> AsyncGenerator[Role, None]:
         """|coro|
         Edits the position of a role.
 
@@ -579,16 +578,15 @@ class Guild(APIObject):
 
         Returns
         -------
-        List[:class:`~pincer.objects.guild.role.Role`]
-            A list of all of the guild's role objects.
+        AsyncGenerator[:class:`~pincer.objects.guild.role.Role`, :data:`None`]
+            An async generator of all of the guild's role objects.
         """
-        return [
-            Role.from_dict(construct_client_dict(self._client, i))
-            for i in await self._http.patch(
-                f"guilds/{self.id}/roles", data={"id": id, "position": position}
-            )
-        ]
-
+        data = await self._http.patch(
+            f"guilds/{self.id}/roles",
+            data={"id": id, "position": position},
+        )
+        for i in data:
+            yield Role.from_dict(construct_client_dict(self._client, i))
     @overload
     async def edit_role(
         self,
@@ -659,19 +657,18 @@ class Guild(APIObject):
         """
         await self._http.delete(f"guilds/{self.id}/roles/{id}")
 
-    async def get_bans(self) -> List[Ban]:
+    async def get_bans(self) -> AsyncGenerator[Ban, None]:
         """|coro|
         Fetches all the bans in the guild.
 
         Returns
         -------
-        List[:class:`~pincer.objects.guild.ban.Ban`]
-            A list of Ban objects.
+        AsyncGenerator[:class:`~pincer.objects.guild.ban.Ban`, :data:`None`]
+            An async generator of Ban objects.
         """
         data = await self._http.get(f"guilds/{self.id}/bans")
-        return [
-            Ban.from_dict(construct_client_dict(self._client, i)) for i in data
-        ]
+        for i in data:
+            yield Ban.from_dict(construct_client_dict(self._client, i))
 
     async def get_ban(self, id: Snowflake) -> Ban:
         """|coro|


### PR DESCRIPTION
### Changes

`adds`: 
- `Guild.get_roles`,
- `Guild.create_role`,
- `Guild.edit_role_position`,
- `Guild.edit_role`,
- `Guild.delete_role`,
- `Guild.get_bans`,
- `Guild.get_ban`,
- `Guild.unban`

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
