### PR TITLE
:art: Middleware no longer returns API objects in list

### DIFF
--- a/pincer/client.py
+++ b/pincer/client.py
@@ -488,14 +488,13 @@ class Client(Dispatcher):
                 )
 
             next_call = get_index(extractable, 0, "")
-            arguments = get_index(extractable, 1, [])
-            params = get_index(extractable, 2, {})
+            ret_object = get_index(extractable, 1, None)
 
         if next_call is None:
             raise RuntimeError(f"Middleware `{key}` has not been registered.")
 
         return (
-            (next_call, arguments, params)
+            (next_call, ret_object)
             if next_call.startswith("on_")
             else await self.handle_middleware(
                 payload, next_call, *arguments, **params
@@ -546,12 +545,12 @@ class Client(Dispatcher):
             what specifically happened.
         """
         try:
-            key, args, kwargs = await self.handle_middleware(payload, name)
+            key, ret_object = await self.handle_middleware(payload, name)
 
-            self.event_mgr.process_events(key, *args)
+            self.event_mgr.process_events(key, ret_object)
 
             if calls := self.get_event_coro(key):
-                self.execute_event(calls, *args, **kwargs)
+                self.execute_event(calls, ret_object)
 
         except Exception as e:
             await self.execute_error(e)

--- a/pincer/middleware/activity_join.py
+++ b/pincer/middleware/activity_join.py
@@ -24,12 +24,13 @@ async def activity_join_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.activity.ActivityJoinEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.activity.ActivityJoinEvent`]
         ``on_activity_join`` and an ``ActivityJoinEvent``
-    """
-    return "on_activity_join", [
+    """  # noqa: E501
+    return (
+        "on_activity_join",
         ActivityJoinEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/activity_join_request.py
+++ b/pincer/middleware/activity_join_request.py
@@ -21,12 +21,13 @@ async def activity_join_request_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.user.User`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.user.User`]
         ``on_activity_join_request`` and a ``User``
     """
-    return "on_activity_join_request", [
+    return (
+        "on_activity_join_request",
         User.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/activity_spectate.py
+++ b/pincer/middleware/activity_spectate.py
@@ -24,12 +24,12 @@ async def activity_spectate_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.event.activity.ActivitySpectateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.event.activity.ActivitySpectateEvent`]
         ``on_activity_spectate`` and an ``ActivitySpectateEvent``
-    """
-    return "on_activity_spectate", [
-        ActivitySpectateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return "on_activity_spectate", ActivitySpectateEvent.from_dict(
+        construct_client_dict(self, payload.data)
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/channel_create.py
+++ b/pincer/middleware/channel_create.py
@@ -6,20 +6,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..core.dispatch import GatewayDispatch
 from ..objects.guild.channel import Channel
 from ..utils.conversion import construct_client_dict
 
 if TYPE_CHECKING:
     from typing import List, Tuple
-
     from ..core.dispatch import GatewayDispatch
 
 
 def channel_create_middleware(
         self,
         payload: GatewayDispatch
-) -> Tuple[str, List[Channel]]:
+) -> Tuple[str, Channel]:
     """|coro|
 
     Middleware for ``on_channel_creation`` event.
@@ -34,9 +32,10 @@ def channel_create_middleware(
     Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
         ``on_channel_creation`` and a channel.
     """
-    return "on_channel_creation", [
+    return (
+        "on_channel_creation",
         Channel.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/channel_delete.py
+++ b/pincer/middleware/channel_delete.py
@@ -20,7 +20,7 @@ async def channel_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.channel.Channel`]
         ``on_channel_delete`` and a ``Channel``
     """
 
@@ -32,7 +32,7 @@ async def channel_delete_middleware(self, payload: GatewayDispatch):
         if old:
             guild.channels.remove(old)
 
-    return "on_channel_delete", [channel]
+    return "on_channel_delete", channel
 
 
 def export():

--- a/pincer/middleware/channel_pins_update.py
+++ b/pincer/middleware/channel_pins_update.py
@@ -19,13 +19,14 @@ async def channel_pins_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.channel.Channel`]
         ``on_channel_pins_update`` and a ``Channel``
     """
 
-    return "on_channel_pins_update", [
+    return (
+        "on_channel_pins_update",
         ChannelPinsUpdateEvent.from_dict(payload.data)
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/channel_update.py
+++ b/pincer/middleware/channel_update.py
@@ -20,7 +20,7 @@ async def channel_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.channel.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.channel.channel.Channel`]
         ``on_channel_update`` and a ``Channel``
     """
 
@@ -33,7 +33,7 @@ async def channel_update_middleware(self, payload: GatewayDispatch):
             guild.channels.remove(old)
         guild.channels.append(channel)
 
-    return "on_channel_update", [channel]
+    return "on_channel_update", channel
 
 
 def export():

--- a/pincer/middleware/error.py
+++ b/pincer/middleware/error.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 def error_middleware(
     self,
     payload: GatewayDispatch
-) -> Tuple[str, List[DiscordError]]:
+) -> Tuple[str, DiscordError]:
     """|coro|
 
     Middleware for ``on_error`` event.
@@ -33,14 +33,15 @@ def error_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.error.DiscordError`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.error.DiscordError`]
         ``on_error`` and a ``DiscordError``
     """
     # noqa: E501
 
-    return "on_error", [
+    return (
+        "on_error",
         DiscordError.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/guild_ban_add.py
+++ b/pincer/middleware/guild_ban_add.py
@@ -21,13 +21,13 @@ async def guild_ban_add_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildBaAddEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildBaAddEvent`]
         ``on_guild_ban_add_update`` and a ``GuildBanAddEvent``
     """
 
     return (
         "on_guild_ban_add",
-        [GuildBanAddEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildBanAddEvent.from_dict(construct_client_dict(self, payload.data)),
     )
 
 

--- a/pincer/middleware/guild_ban_remove.py
+++ b/pincer/middleware/guild_ban_remove.py
@@ -21,13 +21,13 @@ async def guild_ban_remove_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildBanRemoveEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildBanRemoveEvent`]
         ``on_guild_ban_remove_update`` and a ``GuildBanRemoveEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_ban_remove",
-        [GuildBanRemoveEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildBanRemoveEvent.from_dict(construct_client_dict(self, payload.data))
     )
 
 

--- a/pincer/middleware/guild_create.py
+++ b/pincer/middleware/guild_create.py
@@ -27,13 +27,13 @@ async def guild_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.guild.Guild`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.guild.Guild`]
 
         ``on_guild_create`` and a ``Guild``
     """
     guild = Guild.from_dict(construct_client_dict(self, payload.data))
     self.guilds[guild.id] = guild
-    return "on_guild_create", [guild]
+    return "on_guild_create", guild
 
 
 def export():

--- a/pincer/middleware/guild_delete.py
+++ b/pincer/middleware/guild_delete.py
@@ -20,18 +20,20 @@ async def guild_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.guild.UnavailableGuild`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.guild.UnavailableGuild`]
         ``on_guild_delete`` and an ``UnavailableGuild``
     """
     # TODO: Fix docs on line 23 (three lines above)
     # http://docs.pincer.dev/pincer.middleware#pincer.middleware.guild_delete.guild_delete_middleware
 
-    guild = UnavailableGuild.from_dict(construct_client_dict(self, payload.data))
+    guild = UnavailableGuild.from_dict(
+        construct_client_dict(self, payload.data)
+    )
 
     if guild.id in self.guilds.key():
         self.guilds.pop(guild.id)
 
-    return "on_guild_delete", [guild]
+    return "on_guild_delete", guild
 
 
 def export():

--- a/pincer/middleware/guild_emojis_update.py
+++ b/pincer/middleware/guild_emojis_update.py
@@ -21,17 +21,15 @@ async def guild_emojis_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildEmojisUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildEmojisUpdateEvent`]
         ``on_guild_emoji_update`` and a ``GuildEmojisUpdateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_emojis_update",
-        [
-            GuildEmojisUpdateEvent.from_dict(
-                construct_client_dict(self, payload.data)
-            )
-        ],
+        GuildEmojisUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
     )
 
 

--- a/pincer/middleware/guild_integrations_update.py
+++ b/pincer/middleware/guild_integrations_update.py
@@ -21,17 +21,15 @@ async def guild_integrations_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildIntegrationsUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildIntegrationsUpdateEvent`]
         ``on_guild_integration_update`` and a ``GuildIntegrationsUpdateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_integrations_update",
-        [
-            GuildIntegrationsUpdateEvent.from_dict(
-                construct_client_dict(self, payload.data)
-            )
-        ],
+        GuildIntegrationsUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
     )
 
 

--- a/pincer/middleware/guild_member_add.py
+++ b/pincer/middleware/guild_member_add.py
@@ -24,13 +24,14 @@ async def guild_member_add_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildMemberAddEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildMemberAddEvent`]
         ``on_guild_member_add`` and a ``GuildMemberAddEvent``
-    """
+    """  # noqa: E501
 
-    return "on_guild_member_add", [
+    return (
+        "on_guild_member_add",
         GuildMemberAddEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/guild_member_remove.py
+++ b/pincer/middleware/guild_member_remove.py
@@ -23,13 +23,15 @@ async def guild_member_remove_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildMemberRemoveEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildMemberRemoveEvent`]
         ``on_guild_member_remove`` and a ``GuildMemberRemoveEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_member_remove",
-        [GuildMemberRemoveEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildMemberRemoveEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        ),
     )
 
 

--- a/pincer/middleware/guild_member_update.py
+++ b/pincer/middleware/guild_member_update.py
@@ -24,13 +24,15 @@ async def guild_member_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildMemberUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildMemberUpdateEvent`]
         ``on_guild_member_update`` and a ``GuildMemberUpdateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_member_update",
-        [GuildMemberUpdateEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildMemberUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        ),
     )
 
 

--- a/pincer/middleware/guild_members_chunk.py
+++ b/pincer/middleware/guild_members_chunk.py
@@ -24,15 +24,15 @@ async def guild_member_chunk_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildMembersChunkEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildMembersChunkEvent`]
         ``on_guild_member_chunk`` and a ``GuildMembersChunkEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_member_chunk",
-        [GuildMembersChunkEvent.from_dict(
+        GuildMembersChunkEvent.from_dict(
             construct_client_dict(self, payload.data)
-        )]
+        )
     )
 
 

--- a/pincer/middleware/guild_role_create.py
+++ b/pincer/middleware/guild_role_create.py
@@ -21,13 +21,15 @@ async def guild_role_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildRoleCreateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildRoleCreateEvent`]
         ``on_guild_role_create`` and a ``GuildRoleCreateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_role_create",
-        [GuildRoleCreateEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildRoleCreateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
     )
 
 

--- a/pincer/middleware/guild_role_delete.py
+++ b/pincer/middleware/guild_role_delete.py
@@ -21,13 +21,15 @@ async def guild_role_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildRoleDeleteEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildRoleDeleteEvent`]
         ``on_guild_role_delete`` and a ``GuildRoleDeleteEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_role_delete",
-        [GuildRoleDeleteEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildRoleDeleteEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        ),
     )
 
 

--- a/pincer/middleware/guild_role_update.py
+++ b/pincer/middleware/guild_role_update.py
@@ -21,13 +21,15 @@ async def guild_role_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildRoleUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildRoleUpdateEvent`]
         ``on_guild_role_update`` and a ``GuildRoleUpdateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_role_update",
-        [GuildRoleUpdateEvent.from_dict(construct_client_dict(self, payload.data))],
+        GuildRoleUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        ),
     )
 
 

--- a/pincer/middleware/guild_status.py
+++ b/pincer/middleware/guild_status.py
@@ -21,12 +21,13 @@ async def guild_status_middleware(self, payload: GatewayDispatch):
 
     Return
     ------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildStatusEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildStatusEvent`]
         ``on_guild_status`` and a ``GuildStatusEvent``
     """
-    return "on_guild_status", [
+    return (
+        "on_guild_status",
         GuildStatusEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/guild_stickers_update.py
+++ b/pincer/middleware/guild_stickers_update.py
@@ -21,17 +21,15 @@ async def guild_stickers_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.guild.GuildStickersUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.guild.GuildStickersUpdateEvent`]
         ``on_guild_sticker_update`` and a ``GuildStickersUpdateEvent``
-    """
+    """  # noqa: E501
 
     return (
         "on_guild_stickers_update",
-        [
-            GuildStickersUpdateEvent.from_dict(
-                construct_client_dict(self, payload.data)
-            )
-        ],
+        GuildStickersUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
     )
 
 

--- a/pincer/middleware/guild_update.py
+++ b/pincer/middleware/guild_update.py
@@ -21,7 +21,7 @@ async def guild_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.guild.Guild`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.guild.Guild`]
         ``on_guild_Update`` and an ``Guild``
     """
 
@@ -38,7 +38,7 @@ async def guild_update_middleware(self, payload: GatewayDispatch):
     ))
     self.guild[guild.id] = guild
 
-    return "on_guild_update", [guild]
+    return "on_guild_update", guild
 
 
 def export():

--- a/pincer/middleware/integration_create.py
+++ b/pincer/middleware/integration_create.py
@@ -21,12 +21,15 @@ async def integration_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.events.integration.IntegrationCreateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.events.integration.IntegrationCreateEvent`]
         ``on_integration_create`` and an ``IntegrationCreateEvent``
-    """
-    return "on_integration_create", [
-        IntegrationCreateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_integration_create",
+        IntegrationCreateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/integration_delete.py
+++ b/pincer/middleware/integration_delete.py
@@ -21,12 +21,15 @@ async def integration_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.events.integration.IntegrationDeleteEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.events.integration.IntegrationDeleteEvent`]
         ``on_integration_delete`` and an ``IntegrationDeleteEvent``
-    """
-    return "on_integration_delete", [
-        IntegrationDeleteEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_integration_delete",
+        IntegrationDeleteEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/integration_update.py
+++ b/pincer/middleware/integration_update.py
@@ -21,12 +21,15 @@ async def integration_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.events.integration.IntegrationUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.events.integration.IntegrationUpdateEvent`]
         ``on_integration_update`` and an ``IntegrationUpdateEvent``
-    """
-    return "on_integration_update", [
-        IntegrationUpdateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_integration_update",
+        IntegrationUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/interaction_create.py
+++ b/pincer/middleware/interaction_create.py
@@ -125,7 +125,7 @@ async def interaction_handler(
 async def interaction_create_middleware(
     self,
     payload: GatewayDispatch
-) -> Tuple[str, List[Interaction]]:
+) -> Tuple[str, Interaction]:
     """Middleware for ``on_interaction``, which handles command
     execution.
 
@@ -143,9 +143,9 @@ async def interaction_create_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.app.interactions.Interaction`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.app.interactions.Interaction`]
         ``on_interaction_create`` and an ``Interaction``
-    """  # noqa: E501
+    """
     interaction: Interaction = Interaction.from_dict(
         construct_client_dict(self, payload.data)
     )
@@ -177,7 +177,7 @@ async def interaction_create_middleware(
             else:
                 raise e
 
-    return "on_interaction_create", [interaction]
+    return "on_interaction_create", interaction
 
 
 def export() -> Coro:

--- a/pincer/middleware/invite_create.py
+++ b/pincer/middleware/invite_create.py
@@ -21,12 +21,13 @@ async def invite_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.invite.InviteCreateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.invite.InviteCreateEvent`]
         ``on_invite_create`` and an ``InviteCreateEvent``
-    """
-    return "on_invite_create", [
+    """  # noqa: E501
+    return (
+        "on_invite_create",
         InviteCreateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/invite_delete.py
+++ b/pincer/middleware/invite_delete.py
@@ -21,12 +21,13 @@ async def invite_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.events.invite.InviteDeleteEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.events.invite.InviteDeleteEvent`]
         ``on_invite_delete`` and an ``InviteDeleteEvent``
     """
-    return "on_invite_delete", [
+    return (
+        "on_invite_delete",
         InviteDeleteEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/message_create.py
+++ b/pincer/middleware/message_create.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 async def message_create_middleware(
     self,
     payload: GatewayDispatch
-) -> Tuple[str, List[UserMessage]]:  # noqa: E501
+) -> Tuple[str, UserMessage]:  # noqa: E501
     """|coro|
 
     Middleware for ``on_message`` event.
@@ -30,12 +30,13 @@ async def message_create_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.message.user_message.UserMessage`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.message.user_message.UserMessage`]
         ``on_message`` and a ``UserMessage``
     """  # noqa: E501
-    return "on_message", [
+    return (
+        "on_message",
         UserMessage.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_delete.py
+++ b/pincer/middleware/message_delete.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 async def on_message_delete_middleware(
     self,
     payload: GatewayDispatch
-) -> Tuple[str, List[MessageDeleteEvent]]:
+) -> Tuple[str, MessageDeleteEvent]:
     """|coro|
     Middleware for ``on_message_delete`` event.
 
@@ -31,11 +31,12 @@ async def on_message_delete_middleware(
     -------
     Tuple[:class:`str`, :class:`~pincer.objects.events.message.MessageDeleteEvent`]
         ``on_message_delete`` and a ``MessageDeleteEvent``
-    """
+    """  # noqa: E501
 
-    return "on_message_delete", [
+    return (
+        "on_message_delete",
         MessageDeleteEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_delete_bulk.py
+++ b/pincer/middleware/message_delete_bulk.py
@@ -21,12 +21,15 @@ async def message_delete_bulk_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.events.message.MessageDeleteBulkEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.events.message.MessageDeleteBulkEvent`]
         ``on_message_delete_bulk`` and an ``MessageDeleteBulkEvent``
     """
-    return "on_message_delete_bulk", [
-        MessageDeleteBulkEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    return (
+        "on_message_delete_bulk",
+        MessageDeleteBulkEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/message_reaction_add.py
+++ b/pincer/middleware/message_reaction_add.py
@@ -21,11 +21,12 @@ async def message_reaction_add_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.message.MessageReactionAddEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.message.MessageReactionAddEvent`]
         ``on_message_reaction_add`` and an ``MessageReactionAddEvent``
-    """
+    """  # noqa: E501
 
-    return "on_message_reaction_add", [
+    return (
+        "on_message_reaction_add",
         MessageReactionAddEvent.from_dict(
             construct_client_dict(
                 self,
@@ -39,7 +40,7 @@ async def message_reaction_add_middleware(self, payload: GatewayDispatch):
                     **payload.data
                 }
             ))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_reaction_remove.py
+++ b/pincer/middleware/message_reaction_remove.py
@@ -22,11 +22,12 @@ async def message_reaction_remove_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.message.MessageReactionRemoveEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.message.MessageReactionRemoveEvent`]
         ``on_message_reaction_remove`` and an ``MessageReactionRemoveEvent``
-    """
+    """  # noqa: E501
 
-    return "on_message_reaction_remove", [
+    return (
+        "on_message_reaction_remove",
         MessageReactionRemoveEvent.from_dict(
             construct_client_dict(
                 self,
@@ -37,7 +38,7 @@ async def message_reaction_remove_middleware(self, payload: GatewayDispatch):
                     **payload.data
                 }
             ))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_reaction_remove_all.py
+++ b/pincer/middleware/message_reaction_remove_all.py
@@ -24,15 +24,16 @@ async def message_reaction_remove_all_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.message.MessageReactionRemoveAllEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.message.MessageReactionRemoveAllEvent`]
         ``on_message_reaction_remove_all`` and an ``MessageReactionRemoveAllEvent``
-    """
+    """  # noqa: E501
 
-    return "on_message_reaction_remove_all", [
+    return (
+        "on_message_reaction_remove_all",
         MessageReactionRemoveAllEvent.from_dict(
             construct_client_dict(self, payload.data)
         )
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_reaction_remove_emoji.py
+++ b/pincer/middleware/message_reaction_remove_emoji.py
@@ -9,7 +9,9 @@ from ..objects.events.message import MessageReactionRemoveEmojiEvent
 from ..utils.conversion import construct_client_dict
 
 
-async def message_reaction_remove_emoji_middleware(self, payload: GatewayDispatch):
+async def message_reaction_remove_emoji_middleware(
+    self, payload: GatewayDispatch
+):
     """|coro|
 
     Middleware for ``on_message_reaction_remove_emoji`` event.
@@ -22,11 +24,12 @@ async def message_reaction_remove_emoji_middleware(self, payload: GatewayDispatc
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.message.MessageReactionRemoveEmojiEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.message.MessageReactionRemoveEmojiEvent`]
         ``on_message_reaction_remove_emoji`` and an ``MessageReactionRemoveEmojiEvent``
-    """
+    """  # noqa: E501
 
-    return "on_message_reaction_remove_emoji", [
+    return (
+        "on_message_reaction_remove_emoji",
         MessageReactionRemoveEmojiEvent.from_dict(
             construct_client_dict(
                 self,
@@ -37,7 +40,7 @@ async def message_reaction_remove_emoji_middleware(self, payload: GatewayDispatc
                     **payload.data
                 }
             ))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/message_update.py
+++ b/pincer/middleware/message_update.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 async def message_update_middleware(
     self,
     payload: GatewayDispatch
-) -> Tuple[str, List[UserMessage]]:
+) -> Tuple[str, UserMessage]:
     """|coro|
 
 
@@ -33,12 +33,13 @@ async def message_update_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.message.user_message.UserMessage`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.message.user_message.UserMessage`]
         ``on_message_update`` and a ``UserMessage``
-    """
-    return "on_message_update", [
+    """  # noqa: E501
+    return (
+        "on_message_update",
         UserMessage.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/notification_create.py
+++ b/pincer/middleware/notification_create.py
@@ -24,14 +24,17 @@ async def notification_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.notification.NotificationCreateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.notification.NotificationCreateEvent`]
         ``on_notification_create`` and a ``NotificationCreateEvent``
-    """
+    """  # noqa: E501
     channel_id: int = payload.data.get("channel_id")
     payload.data["message"]["channel_id"] = channel_id
-    return "on_notification_create", [
-        NotificationCreateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    return (
+        "on_notification_create",
+        NotificationCreateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/payload.py
+++ b/pincer/middleware/payload.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 async def payload_middleware(
     payload: GatewayDispatch
-) -> Tuple[str, List[GatewayDispatch]]:
+) -> Tuple[str, GatewayDispatch]:
     """Invoked when basically anything is received from gateway.
 
     Parameters
@@ -24,10 +24,10 @@ async def payload_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.core.dispatch.GatewayDispatch`]]
+    Tuple[:class:`str`, :class:`~pincer.core.dispatch.GatewayDispatch`]
         ``on_payload`` and a ``payload``
     """
-    return "on_payload", [payload]
+    return "on_payload", payload
 
 
 def export():

--- a/pincer/middleware/presence_update.py
+++ b/pincer/middleware/presence_update.py
@@ -21,12 +21,13 @@ async def presence_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.voice_state.PresenceUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.voice_state.PresenceUpdateEvent`]
         ``on_presence_update`` and a ``PresenceUpdateEvent``
-    """
-    return "on_presence_update", [
+    """  # noqa: E501
+    return (
+        "on_presence_update",
         PresenceUpdateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/speaking_start.py
+++ b/pincer/middleware/speaking_start.py
@@ -21,12 +21,13 @@ async def speaking_start_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`SpeakingStartEvent`]]
+    Tuple[:class:`str`, :class:`SpeakingStartEvent`]
         ``on_speaking_start`` and a ``SpeakingStartEvent``
     """
-    return "on_speaking_start", [
+    return (
+        "on_speaking_start",
         SpeakingStartEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/speaking_stop.py
+++ b/pincer/middleware/speaking_stop.py
@@ -21,12 +21,13 @@ async def speaking_stop_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`Snowflake`]]
+    Tuple[:class:`str`, :class:`Snowflake`]
         ``on_speaking_stop`` and a ``Snowflake`` (user_id)
     """
-    return "on_speaking_stop", [
+    return (
+        "on_speaking_stop",
         SpeakingStopEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/stage_instance_create.py
+++ b/pincer/middleware/stage_instance_create.py
@@ -20,13 +20,14 @@ def stage_instance_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.stage.StageInstance`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.stage.StageInstance`]
         ``on_stage_instance_create`` and a ``StageInstance``
     """
 
-    return "on_stage_instance_create", [
+    return (
+        "on_stage_instance_create",
         StageInstance.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/stage_instance_delete.py
+++ b/pincer/middleware/stage_instance_delete.py
@@ -20,13 +20,14 @@ def stage_instance_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.stage.StageInstance`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.stage.StageInstance`]
         ``on_stage_instance_delete`` and a ``StageInstance``
     """
 
-    return "on_stage_instance_delete", [
+    return (
+        "on_stage_instance_delete",
         StageInstance.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/stage_instance_update.py
+++ b/pincer/middleware/stage_instance_update.py
@@ -20,13 +20,14 @@ def stage_instance_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.stage.StageInstance`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.stage.StageInstance`]
         ``on_stage_instance_update`` and a ``StageInstance``
     """
 
-    return "on_stage_instance_update", [
+    return (
+        "on_stage_instance_update",
         StageInstance.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/thread_create.py
+++ b/pincer/middleware/thread_create.py
@@ -20,13 +20,14 @@ def thread_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.channel.Channel`]
         ``on_thread_create`` and an ``Channel``
     """
 
-    return "on_thread_create", [
+    return (
+        "on_thread_create",
         Channel.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/thread_delete.py
+++ b/pincer/middleware/thread_delete.py
@@ -20,13 +20,14 @@ async def thread_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.channel.Channel`]
         ``on_thread_delete`` and an ``Channel``
     """
 
-    return "on_thread_delete", [
+    return (
+        "on_thread_delete",
         Channel.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/thread_list_sync.py
+++ b/pincer/middleware/thread_list_sync.py
@@ -25,9 +25,9 @@ async def thread_list_sync(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.events.thread.ThreadListSyncEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.events.thread.ThreadListSyncEvent`]
         ``on_thread_list_sync`` and an ``ThreadListSyncEvent``
-    """
+    """  # noqa: E501
 
     threads: List[Channel] = [
         Channel.from_dict(construct_client_dict(self, thread))
@@ -39,11 +39,12 @@ async def thread_list_sync(self, payload: GatewayDispatch):
         for member in payload.data.pop("members")
     ]
 
-    return "on_thread_list_sync", [
+    return (
+        "on_thread_list_sync",
         ThreadListSyncEvent.from_dict(
             {"threads": threads, "members": members, **payload.data}
         )
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/thread_member_update.py
+++ b/pincer/middleware/thread_member_update.py
@@ -21,11 +21,12 @@ async def thread_member_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.thread.ThreadMember`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.thread.ThreadMember`]
         ``on_thread_member_update`` and an ``ThreadMember``
     """
 
-    return "on_thread_member_update", [
+    return (
+        "on_thread_member_update",
         ThreadMember.from_dict(construct_client_dict(
             self,
             {
@@ -33,7 +34,7 @@ async def thread_member_update_middleware(self, payload: GatewayDispatch):
                 **payload.data
             }
         ))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/thread_members_update.py
+++ b/pincer/middleware/thread_members_update.py
@@ -24,9 +24,9 @@ async def thread_members_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.thread.ThreadMembersUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.thread.ThreadMembersUpdateEvent`]
         ``on_thread_members_update`` and an ``ThreadMembersUpdateEvent``
-    """
+    """  # noqa: E501
 
     added_members: List[ThreadMember] = [
         ThreadMember.from_dict(construct_client_dict(
@@ -39,14 +39,15 @@ async def thread_members_update_middleware(self, payload: GatewayDispatch):
         for added_member in payload.data.pop("added_members")
     ]
 
-    return "on_thread_members_update", [
+    return (
+        "on_thread_members_update",
         ThreadMembersUpdateEvent.from_dict(
             {
                 "added_members": added_members,
                 **payload.data
             }
         )
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/thread_update.py
+++ b/pincer/middleware/thread_update.py
@@ -21,13 +21,14 @@ async def thread_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.guild.channel.Channel`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.guild.channel.Channel`]
         ``on_thread_update`` and an ``Channel``
     """
 
-    return "on_thread_update", [
+    return (
+        "on_thread_update",
         Channel.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/typing_start.py
+++ b/pincer/middleware/typing_start.py
@@ -21,12 +21,13 @@ async def typing_start_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.typing_start.TypingStartEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.typing_start.TypingStartEvent`]
         ``on_typing_start`` and a ``TypingStartEvent``
-    """
-    return "on_typing_start", [
+    """  # noqa: E501
+    return (
+        "on_typing_start",
         TypingStartEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/user_update.py
+++ b/pincer/middleware/user_update.py
@@ -21,12 +21,13 @@ async def user_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.user.User`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.user.User`]
         ``on_user_update`` and a ``User``
     """
-    return "on_user_update", [
+    return (
+        "on_user_update",
         User.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_channel_select.py
+++ b/pincer/middleware/voice_channel_select.py
@@ -21,12 +21,15 @@ async def voice_channel_select_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.voice.VoiceChannelSelectEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.voice.VoiceChannelSelectEvent`]
         ``on_voice_channel_select`` and a ``VoiceChannelSelectEvent``
-    """
-    return "on_voice_channel_select", [
-        VoiceChannelSelectEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_voice_channel_select",
+        VoiceChannelSelectEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_connection_status.py
+++ b/pincer/middleware/voice_connection_status.py
@@ -21,12 +21,15 @@ async def voice_connection_status_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.voice.VoiceConnectionStatusEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.voice.VoiceConnectionStatusEvent`]
         ``on_voice_connection_status`` and a ``VoiceConnectionStatusEvent``
-    """
-    return "on_voice_connection_status", [
-        VoiceConnectionStatusEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_voice_connection_status",
+        VoiceConnectionStatusEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_server_update.py
+++ b/pincer/middleware/voice_server_update.py
@@ -21,12 +21,15 @@ async def voice_server_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.voice.VoiceServerUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.voice.VoiceServerUpdateEvent`]
         ``on_voice_server_update`` and a ``VoiceServerUpdateEvent``
-    """
-    return "on_voice_server_update", [
-        VoiceServerUpdateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_voice_server_update",
+        VoiceServerUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_settings_update.py
+++ b/pincer/middleware/voice_settings_update.py
@@ -21,12 +21,15 @@ async def voice_settings_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.VoiceSettingsUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.VoiceSettingsUpdateEvent`]
         ``on_voice_settings_update`` and a ``VoiceSettingsUpdateEvent``
-    """
-    return "on_voice_settings_update", [
-        VoiceSettingsUpdateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    """  # noqa: E501
+    return (
+        "on_voice_settings_update",
+        VoiceSettingsUpdateEvent.from_dict(
+            construct_client_dict(self, payload.data)
+        )
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_state_create.py
+++ b/pincer/middleware/voice_state_create.py
@@ -21,12 +21,13 @@ async def voice_state_create_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.voice_state.VoiceState`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.voice_state.VoiceState`]
         ``on_voice_state_create`` and a ``VoiceState``
     """
-    return "on_voice_state_create", [
+    return (
+        "on_voice_state_create",
         VoiceState.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_state_delete.py
+++ b/pincer/middleware/voice_state_delete.py
@@ -21,12 +21,13 @@ async def voice_state_delete_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.voice_state.VoiceState`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.voice_state.VoiceState`]
         ``on_voice_state_delete`` and a ``VoiceState``
     """
-    return "on_voice_state_delete", [
+    return (
+        "on_voice_state_delete",
         VoiceState.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export() -> Coro:

--- a/pincer/middleware/voice_state_update.py
+++ b/pincer/middleware/voice_state_update.py
@@ -32,14 +32,15 @@ async def voice_state_update_middleware(
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.user.voice_state.VoiceState`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.user.voice_state.VoiceState`]
         ``on_voice_state_update`` and a ``VoiceState``
     """
     # noqa: E501
 
-    return "on_voice_state_update", [
+    return (
+        "on_voice_state_update",
         VoiceState.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():

--- a/pincer/middleware/webhooks_update.py
+++ b/pincer/middleware/webhooks_update.py
@@ -23,12 +23,13 @@ async def webhooks_update_middleware(self, payload: GatewayDispatch):
 
     Returns
     -------
-    Tuple[:class:`str`, List[:class:`~pincer.objects.events.webhook.WebhooksUpdateEvent`]]
+    Tuple[:class:`str`, :class:`~pincer.objects.events.webhook.WebhooksUpdateEvent`]
         ``on_webhooks_update`` and a ``WebhooksUpdateEvent``
-    """
-    return "on_webhooks_update", [
+    """  # noqa: E501
+    return (
+        "on_webhooks_update",
         WebhooksUpdateEvent.from_dict(construct_client_dict(self, payload.data))
-    ]
+    )
 
 
 def export():


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes
-   `improvements`: Middleware doesn't return API objects in a list since it wasn't used once after implemented all the documented Middleware. This let me simplify the code in Client and EventMgr.
 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
