### PR TITLE
:sparkles: Added `GuildTemplate` related endpoints

### DIFF
--- a/pincer/client.py
+++ b/pincer/client.py
@@ -21,8 +21,10 @@ from .exceptions import (
 )
 from .middleware import middleware
 from .objects import (
-    Role, Channel, DefaultThrottleHandler, User, Guild, Intents
+    Role, Channel, DefaultThrottleHandler, User, Guild, Intents,
+    GuildTemplate
 )
+from .utils.conversion import construct_client_dict
 from .utils.event_mgr import EventMgr
 from .utils.extraction import get_index
 from .utils.insertion import should_pass_cls
@@ -646,6 +648,27 @@ class Client(Dispatcher):
     async def create_guild(self, name: str, **kwargs) -> Guild:
         g = await self.http.post("guilds", data={"name": name, **kwargs})
         return await self.get_guild(g['id'])
+
+    async def get_guild_template(self, code: str) -> GuildTemplate:
+        """|coro|
+        Retrieves a guild template by its code.
+
+        Parameters
+        ----------
+        code : :class:`str`
+            The code of the guild template
+
+        Returns
+        -------
+        :class:`~pincer.objects.guild.template.GuildTemplate`
+            The guild template
+        """
+        return GuildTemplate.from_dict(
+            construct_client_dict(
+                self, 
+                await self.http.get(f"guilds/templates/{code}")
+            )
+        )
 
     async def wait_for(
             self,

--- a/pincer/client.py
+++ b/pincer/client.py
@@ -670,6 +670,39 @@ class Client(Dispatcher):
             )
         )
 
+    async def create_guild_from_template(
+        self,
+        template: GuildTemplate,
+        name: str,
+        icon: Optional[str] = None
+    ) -> Guild:
+        """|coro|
+        Creates a guild from a template.
+
+        Parameters
+        ----------
+        template : :class:`~pincer.objects.guild.template.GuildTemplate`
+            The guild template
+        name : :class:`str`
+            Name of the guild (2-100 characters)
+        icon : Optional[:class:`str`]
+            base64 128x128 image for the guild icon |default| :data:`None`
+
+        Returns
+        -------
+        :class:`~pincer.objects.guild.guild.Guild`
+            The created guild
+        """
+        return Guild.from_dict(
+            construct_client_dict(
+                self,
+                await self.http.post(
+                    f"guilds/templates/{template.code}",
+                    data={"name": name, "icon": icon}
+                )
+            )
+        )
+
     async def wait_for(
             self,
             event_name: str,

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -1444,6 +1444,31 @@ class Guild(APIObject):
             construct_client_dict(self._client, data)
         )
 
+    async def sync_template(
+        self,
+        template: GuildTemplate
+    ) -> GuildTemplate:
+        """|coro|
+        Syncs the given template.
+        Requires the ``MANAGE_GUILD`` permission.
+
+        Parameters
+        ----------
+        template : :class:`~pincer.objects.guild.template.GuildTemplate`
+            The template to sync
+
+        Returns
+        -------
+        :class:`~pincer.objects.guild.template.GuildTemplate`
+            The synced template object.
+        """
+        data = await self._http.put(
+            f"guilds/{self.id}/templates/{template.code}"
+        )
+        return GuildTemplate.from_dict(
+            construct_client_dict(self._client, data)
+        )
+
     @classmethod
     def from_dict(cls, data) -> Guild:
         """

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from .features import GuildFeature
     from .role import Role
     from .stage import StageInstance
+    from .template import GuildTemplate
     from .welcome_screen import WelcomeScreen, WelcomeScreenChannel
     from .widget import GuildWidget
     from ..user.user import User
@@ -1395,6 +1396,21 @@ class Guild(APIObject):
             f"guilds/{self.id}/emojis/{id}",
             headers=remove_none({"X-Audit-Log-Reason": reason})
         )
+
+    async def get_templates(self) -> AsyncGenerator[GuildTemplate, None]:
+        """|coro|
+        Returns an async generator of the guild templates.
+
+        Yields
+        -------
+        AsyncGenerator[:class:`~pincer.objects.guild.template.GuildTemplate`, :data:`None`]
+            The guild template object.
+        """
+        data = await self._http.get(f"guilds/{self.id}/templates")
+        for template_data in data:
+            yield GuildTemplate.from_dict(
+                construct_client_dict(self._client, template_data)
+            )
 
     @classmethod
     def from_dict(cls, data) -> Guild:

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -1507,6 +1507,31 @@ class Guild(APIObject):
             construct_client_dict(self._client, data)
         )
 
+    async def delete_template(
+        self,
+        template: GuildTemplate
+    ) -> GuildTemplate:
+        """|coro|
+        Deletes the given template.
+        Requires the ``MANAGE_GUILD`` permission.
+
+        Parameters
+        ----------
+        template : :class:`~pincer.objects.guild.template.GuildTemplate`
+            The template to delete
+        
+        Returns
+        -------
+        :class:`~pincer.objects.guild.template.GuildTemplate`
+            The deleted template object.
+        """
+        data = await self._http.delete(
+            f"guilds/{self.id}/templates/{template.code}"
+        )
+        return GuildTemplate.from_dict(
+            construct_client_dict(self._client, data)
+        )
+
     @classmethod
     def from_dict(cls, data) -> Guild:
         """

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -1412,6 +1412,38 @@ class Guild(APIObject):
                 construct_client_dict(self._client, template_data)
             )
 
+    async def create_template(
+        self,
+        name: str,
+        description: Optional[str] = None
+    ) -> GuildTemplate:
+        """|coro|
+        Creates a new template for the guild.
+        Requires the ``MANAGE_GUILD`` permission.
+
+        Parameters
+        ----------
+        name : :class:`str`
+            Name of the template (1-100 characters)
+        description : Optional[:class:`str`]
+            Description of the template
+            (0-120 characters) |default| :data:`None`
+        Returns
+        -------
+        :class:`~pincer.objects.guild.template.GuildTemplate`
+            The newly created template object.
+        """
+        data = await self._http.post(
+            f"guilds/{self.id}/templates",
+            data={
+                "name": name,
+                "description": description
+            }
+        )
+        return GuildTemplate.from_dict(
+            construct_client_dict(self._client, data)
+        )
+
     @classmethod
     def from_dict(cls, data) -> Guild:
         """

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -1469,6 +1469,44 @@ class Guild(APIObject):
             construct_client_dict(self._client, data)
         )
 
+    async def edit_template(
+        self,
+        template: GuildTemplate,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None
+    ) -> GuildTemplate:
+        """|coro|
+        Modifies the template's metadata.
+        Requires the ``MANAGE_GUILD`` permission.
+
+        Parameters
+        ----------
+        template : :class:`~pincer.objects.guild.template.GuildTemplate`
+            The template to edit
+        name : Optional[:class:`str`]
+            Name of the template (1-100 characters)
+            |default| :data:`None`
+        description : Optional[:class:`str`]
+            Description of the template (0-120 characters)
+            |default| :data:`None`
+
+        Returns
+        -------
+        :class:`~pincer.objects.guild.template.GuildTemplate`
+            The edited template object.
+        """
+        data = await self._http.patch(
+            f"guilds/{self.id}/templates/{template.code}",
+            data={
+                "name": name,
+                "description": description
+            }
+        )
+        return GuildTemplate.from_dict(
+            construct_client_dict(self._client, data)
+        )
+
     @classmethod
     def from_dict(cls, data) -> Guild:
         """


### PR DESCRIPTION
### Adds
- `Client.get_guild_template`
- `Guild.get_templates`
- `Guild.create_template`
- `Guild.sync_template`
- `Guild.edit_template`
- `Guild.delete_template`

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
