### PR TITLE
:passport_control: added User-Agent header

### DIFF
--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -9,6 +9,8 @@ from typing import Protocol, TYPE_CHECKING
 
 from aiohttp import ClientSession, ClientResponse
 
+# Im open for ideas on how to get __version__ without doing this
+import pincer
 from . import __package__
 from .._config import GatewayConfig
 from ..exceptions import (
@@ -73,6 +75,7 @@ class HTTPClient:
 
         headers: Dict[str, str] = {
             "Authorization": f"Bot {token}",
+            "User-Agent": f"DiscordBot (https://github.com/Pincer-org/Pincer, {pincer.__version__})"  # noqa: E501
         }
         self.__session: ClientSession = ClientSession(headers=headers)
 


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `adds`: User-Agent header. Read the docs and realized I missed this lol. Would've stopped us from being added to the discord libs in the docs if we didn't have it.
Im open to suggestions on how to make this not suck :pensive: 

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
