### PR TITLE
🐛 Transform `message.edit` list of APIObject to JSONSerializable

### DIFF
--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import TYPE_CHECKING
+from collections import defaultdict
 
 from .attachment import Attachment
 from .component import MessageComponent
@@ -49,7 +50,7 @@ class AllowedMentionTypes(str, Enum):
     EVERYONE = "everyone"
 
 
-@dataclass(repr=False)
+@dataclass
 class AllowedMentions(APIObject):
     """Represents the entities the client can mention
 
@@ -229,7 +230,7 @@ class MessageType(IntEnum):
     CONTEXT_MENU_COMMAND = 23
 
 
-@dataclass(repr=False)
+@dataclass
 class MessageActivity(APIObject):
     """Represents a Discord Message Activity object
 
@@ -244,7 +245,7 @@ class MessageActivity(APIObject):
     party_id: APINullable[str] = MISSING
 
 
-@dataclass(repr=False)
+@dataclass
 class UserMessage(APIObject):
     """Represents a message sent in a channel within Discord.
 
@@ -511,20 +512,15 @@ class UserMessage(APIObject):
             the components to include with the message
         """
 
-        data = {}
+        data: DefaultDict[str, JsonVal] = defaultdict(list)
 
         def set_if_not_none(value: Any, name: str):
             if isinstance(value, list):
-                data[name] = []
                 for item in value:
                     return set_if_not_none(item, name)
 
             if isinstance(value, APIObject):
-                d = value.to_dict()
-                if name in data:
-                    data[name].append(d)
-                else:
-                    data[name] = d
+                data[name].append(value.to_dict())
 
             elif value is not None:
                 data[name] = value

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -23,7 +23,7 @@ from ..._config import GatewayConfig
 from ...utils.api_object import APIObject
 from ...utils.conversion import construct_client_dict
 from ...utils.snowflake import Snowflake
-from ...utils.types import MISSING
+from ...utils.types import MISSING, JSONSerializable
 
 if TYPE_CHECKING:
     from typing import Any, List, Optional, Union, Generator
@@ -512,7 +512,7 @@ class UserMessage(APIObject):
             the components to include with the message
         """
 
-        data: DefaultDict[str, JsonVal] = defaultdict(list)
+        data: DefaultDict[str, JSONSerializable] = defaultdict(list)
 
         def set_if_not_none(value: Any, name: str):
             if isinstance(value, list):

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, IntEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, DefaultDict
 from collections import defaultdict
 
 from .attachment import Attachment
@@ -50,7 +50,7 @@ class AllowedMentionTypes(str, Enum):
     EVERYONE = "everyone"
 
 
-@dataclass
+@dataclass(repr=False)
 class AllowedMentions(APIObject):
     """Represents the entities the client can mention
 
@@ -230,7 +230,7 @@ class MessageType(IntEnum):
     CONTEXT_MENU_COMMAND = 23
 
 
-@dataclass
+@dataclass(repr=False)
 class MessageActivity(APIObject):
     """Represents a Discord Message Activity object
 
@@ -245,7 +245,7 @@ class MessageActivity(APIObject):
     party_id: APINullable[str] = MISSING
 
 
-@dataclass
+@dataclass(repr=False)
 class UserMessage(APIObject):
     """Represents a message sent in a channel within Discord.
 

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -514,8 +514,18 @@ class UserMessage(APIObject):
         data = {}
 
         def set_if_not_none(value: Any, name: str):
+            if isinstance(value, list):
+                data[name] = []
+                for item in value:
+                    return set_if_not_none(item, name)
+
             if isinstance(value, APIObject):
-                data[name] = value.to_dict()
+                d = value.to_dict()
+                if name in data:
+                    data[name].append(d)
+                else:
+                    data[name] = d
+
             elif value is not None:
                 data[name] = value
 


### PR DESCRIPTION
### Changes

-   `fixed`: uses recursion to transform all APIObject objects into JSON serializable, because things like Embed are in list and were not set as json objects like mentionned in #305 :/

 ### Check off the following

-   [X] I have tested my changes with the current requirements
-   [X] My Code follows the pep8 code style.
