### PR TITLE
:sparkles: Moved InviteMetadata to Invite

### DIFF
--- a/pincer/objects/__init__.py
+++ b/pincer/objects/__init__.py
@@ -65,7 +65,7 @@ from .guild.guild import (
     Guild
 )
 from .guild.invite import (
-    InviteTargetType, InviteStageInstance, InviteMetadata, Invite
+    InviteTargetType, InviteStageInstance, Invite
 )
 from .guild.member import GuildMember, PartialGuildMember, BaseMember
 from .guild.overwrite import Overwrite
@@ -129,20 +129,19 @@ __all__ = (
     "IntegrationAccount", "IntegrationApplication", "IntegrationDeleteEvent",
     "IntegrationExpireBehavior", "Intents", "Interaction", "InteractionData",
     "InteractionFlags", "InteractionType", "Invite", "InviteCreateEvent",
-    "InviteDeleteEvent", "InviteMetadata", "InviteStageInstance",
-    "InviteTargetType", "MFALevel", "Mentionable", "Message",
-    "MessageActivity", "MessageActivityType", "MessageComponent",
-    "MessageContext", "MessageDeleteBulkEvent", "MessageDeleteEvent",
-    "MessageFlags", "MessageInteraction", "MessageReactionAddEvent",
-    "MessageReactionRemoveAllEvent", "MessageReactionRemoveEmojiEvent",
-    "MessageReactionRemoveEvent", "MessageReference", "MessageType",
-    "NewsChannel", "Overwrite", "PartialGuildMember", "PremiumTier",
-    "PremiumTypes", "PresenceUpdateEvent", "PrivacyLevel", "Reaction",
-    "ReadyEvent", "RequestGuildMembers", "ResolvedData", "Resume", "Role",
-    "RoleTags", "SelectMenu", "SelectOption", "SessionStartLimit",
-    "StageInstance", "StatusType", "Sticker", "StickerFormatType",
-    "StickerItem", "StickerPack", "StickerType", "SystemChannelFlags",
-    "TextChannel", "ThreadListSyncEvent", "ThreadMember",
+    "InviteDeleteEvent", "InviteStageInstance", "InviteTargetType", "MFALevel",
+    "Mentionable", "Message", "MessageActivity", "MessageActivityType",
+    "MessageComponent", "MessageContext", "MessageDeleteBulkEvent",
+    "MessageDeleteEvent", "MessageFlags", "MessageInteraction",
+    "MessageReactionAddEvent", "MessageReactionRemoveAllEvent",
+    "MessageReactionRemoveEmojiEvent", "MessageReactionRemoveEvent",
+    "MessageReference", "MessageType", "NewsChannel", "Overwrite",
+    "PartialGuildMember", "PremiumTier", "PremiumTypes", "PresenceUpdateEvent",
+    "PrivacyLevel", "Reaction", "ReadyEvent", "RequestGuildMembers",
+    "ResolvedData", "Resume", "Role", "RoleTags", "SelectMenu", "SelectOption",
+    "SessionStartLimit", "StageInstance", "StatusType", "Sticker",
+    "StickerFormatType", "StickerItem", "StickerPack", "StickerType",
+    "SystemChannelFlags", "TextChannel", "ThreadListSyncEvent", "ThreadMember",
     "ThreadMembersUpdateEvent", "ThreadMetadata", "ThrottleInterface",
     "ThrottleScope", "TypingStartEvent", "UpdatePresence", "UpdateVoiceState",
     "User", "UserMessage", "VerificationLevel", "VisibilityType",

--- a/pincer/objects/guild/__init__.py
+++ b/pincer/objects/guild/__init__.py
@@ -17,7 +17,7 @@ from .guild import (
     Guild, UnavailableGuild
 )
 from .invite import (
-    InviteTargetType, InviteStageInstance, InviteMetadata, Invite
+    InviteTargetType, InviteStageInstance, Invite
 )
 from .member import GuildMember, PartialGuildMember, BaseMember
 from .overwrite import Overwrite
@@ -38,10 +38,10 @@ __all__ = (
     "EventStatus", "ExplicitContentFilterLevel", "FollowedChannel", "Guild",
     "GuildFeature", "GuildMember", "GuildNSFWLevel",
     "GuildScheduledEventEntityType", "GuildTemplate", "GuildWidget", "Invite",
-    "InviteMetadata", "InviteStageInstance", "InviteTargetType", "MFALevel",
-    "NewsChannel", "Overwrite", "PartialGuildMember", "PremiumTier",
-    "PrivacyLevel", "Role", "RoleTags", "ScheduledEvent", "StageInstance",
-    "SystemChannelFlags", "TextChannel", "ThreadMember", "ThreadMetadata",
-    "UnavailableGuild", "VerificationLevel", "VoiceChannel", "Webhook",
-    "WebhookType", "WelcomeScreen", "WelcomeScreenChannel"
+    "InviteStageInstance", "InviteTargetType", "MFALevel", "NewsChannel",
+    "Overwrite", "PartialGuildMember", "PremiumTier", "PrivacyLevel", "Role",
+    "RoleTags", "ScheduledEvent", "StageInstance", "SystemChannelFlags",
+    "TextChannel", "ThreadMember", "ThreadMetadata", "UnavailableGuild",
+    "VerificationLevel", "VoiceChannel", "Webhook", "WebhookType",
+    "WelcomeScreen", "WelcomeScreenChannel"
 )

--- a/pincer/objects/guild/invite.py
+++ b/pincer/objects/guild/invite.py
@@ -58,30 +58,6 @@ class InviteStageInstance(APIObject):
 
 
 @dataclass(repr=False)
-class InviteMetadata(APIObject):
-    """Extra information about an invite, will extend the invite object.
-
-    Attributes
-    ----------
-    uses: :class:`int`
-        number of times this invite has been used
-    max_uses: :class:`int`
-        Max number of times this invite can be used
-    max_age: :class:`int`
-        Duration (in seconds) after which the invite expires
-    temporary:  :class:`bool`
-        Whether this invite only grants temporary membership
-    created_at: :class:`~pincer.utils.timestamp.Timestamp`
-        When this invite was created
-    """
-    uses: int
-    max_uses: int
-    max_age: int
-    temporary: bool
-    created_at: Timestamp
-
-
-@dataclass(repr=False)
 class Invite(APIObject):
     """Represents a Discord invite.
 
@@ -114,6 +90,16 @@ class Invite(APIObject):
     target_application: :class:`~pincer.objects.app.application.Application`
         The embedded application to open for this voice channel embedded
         application invite
+    uses: APINullable[:class:`int`]
+        number of times this invite has been used
+    max_uses: APINullable[:class:`int`]
+        Max number of times this invite can be used
+    max_age: APINullable[:class:`int`]
+        Duration (in seconds) after which the invite expires
+    temporary:  APINullable[:class:`bool`]
+        Whether this invite only grants temporary membership
+    created_at: APINullable[:class:`~pincer.utils.timestamp.Timestamp`]
+        When this invite was created
     """
     # noqa: E501
 
@@ -129,6 +115,11 @@ class Invite(APIObject):
     target_type: APINullable[InviteTargetType] = MISSING
     target_user: APINullable[User] = MISSING
     target_application: APINullable[Application] = MISSING
+    uses: APINullable[int] = MISSING
+    max_uses: APINullable[int] = MISSING
+    max_age: APINullable[int] = MISSING
+    temporary: APINullable[bool] = MISSING
+    created_at: APINullable[Timestamp] = MISSING
 
     def __repr__(self) -> str:
         return f"Invite(code={self.code}, channel={self.channel})"

--- a/pincer/objects/guild/invite.py
+++ b/pincer/objects/guild/invite.py
@@ -59,7 +59,7 @@ class InviteStageInstance(APIObject):
 
 @dataclass(repr=False)
 class Invite(APIObject):
-    """Represents a Discord invite.
+    """Represents a Discord invite. Can also include information from InviteMetadata.
 
     Attributes
     ----------


### PR DESCRIPTION
### Changes

-   `adds`: `Invite.uses`, `Invite.max_uses`, `Invite.max_age`, `Invite.temporary`, `Invite.created_at`
-   `removed`: `InviteMetadata`

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
