### PR TITLE
:arrow_up: Adding Python 3.10 as supported

### DIFF
--- a/setup_config/base.cfg
+++ b/setup_config/base.cfg
@@ -29,8 +29,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    
-
 [options]
 include_package_data = True
 packages =

--- a/setup_config/base.cfg
+++ b/setup_config/base.cfg
@@ -28,6 +28,8 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    
 
 [options]
 include_package_data = True


### PR DESCRIPTION
### Changes

Just adds the 3.10 classifier

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
