### PR TITLE
Message options

### DIFF
--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Tuple, List
 from typing import Union
 
-from ..objects import MessageComponent, AllowedMentions
 from ..objects.app.interaction_flags import InteractionFlags
+from ..objects.message.components import MessageComponent
 from ..objects.message.embed import Embed
 from ..objects.message.file import File
 from ..objects.message.message import Message
+from ..objects.message.user_message import AllowedMentions
 
 PILLOW_IMPORT = True
 

--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -24,10 +24,7 @@ if TYPE_CHECKING:
 MessageConvertable = Union[Embed, Message, str]
 
 
-def convert_message(
-        client: Client,
-        message: MessageConvertable
-) -> Message:
+def convert_message(client: Client, message: MessageConvertable) -> Message:
     # TODO: fix docs
     """
     Converts a message to a Message object.
@@ -46,8 +43,11 @@ def convert_message(
     elif PILLOW_IMPORT and isinstance(message, (File, Image)):
         message = Message(attachments=[message])
     elif not isinstance(message, Message):
-        message = Message(message) if message else Message(
-            client.received_message,
-            flags=InteractionFlags.EPHEMERAL
+        message = (
+            Message(message)
+            if message
+            else Message(
+                client.received_message, flags=InteractionFlags.EPHEMERAL
+            )
         )
     return message

--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -55,7 +55,8 @@ def convert_message(client: Client, message: MessageConvertable) -> Message:
             Message(message)
             if message
             else Message(
-                client.received_message, flags=InteractionFlags.EPHEMERAL
+                client.received_message,
+                flags=InteractionFlags.EPHEMERAL
             )
         )
     return message

--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -69,4 +69,4 @@ def list_to_message_dict(item, kwargs):
     elif isinstance(item, MessageComponent):
         kwargs["components"].append(item)
     elif isinstance(item, str):
-        kwargs["content"] = ""
+        kwargs["content"] = item

--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Tuple, List
 from typing import Union
 
 from ..objects.app.interaction_flags import InteractionFlags
-from ..objects.message.components import MessageComponent
+from ..objects.message.component import MessageComponent
 from ..objects.message.embed import Embed
 from ..objects.message.file import File
 from ..objects.message.message import Message

--- a/pincer/utils/convert_message.py
+++ b/pincer/utils/convert_message.py
@@ -11,7 +11,6 @@ from ..objects.message.component import MessageComponent
 from ..objects.message.embed import Embed
 from ..objects.message.file import File
 from ..objects.message.message import Message
-from ..objects.message.user_message import AllowedMentions
 
 PILLOW_IMPORT = True
 


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `adds`: docstring on `convert_message`
-   `improvements`: a list of items can be used instead in the convert message function.

example usage:

```py
# before
@command
async def help(ctx):
    return Message(content="Help Command", attachements=[img_A, img_b], embed=[an_embed], component=[button1, button2]

# now
@command
async def help(ctx):
    return "Help Command", img_A, img_b, an_embed, button1, button2

```

Both methods work but the new one "converts" it into a message object with all the properties.

 ### Check off the following

-   [ ] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
