### PR TITLE
:bug: Fixes post_send_handler deleting channel instead of message

### DIFF
--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -508,7 +508,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             headers=remove_none({"X-Audit-Log-Reason": reason})
         )
 
-    async def __post_send_handler(self, message: Message):
+    async def __post_send_handler(self, message: UserMessage):
         """Process a message after it was sent.
 
         Parameters
@@ -519,11 +519,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         if getattr(message, "delete_after", None):
             await sleep(message.delete_after)
-            await self.delete()
+            await message.delete()
 
     def __post_sent(
         self,
-        message: Message
+        message: UserMessage
     ):
         """Ensure the `__post_send_handler` method its future.
 


### PR DESCRIPTION
### Changes

-   `fixed`:  __post_send_handler now deletes message instead of channel.
-   `fixed`:  __post_send and __post_send_handler type hints.

Currently http and delete_after aren't passed to UserMessage so this code never runs.

 ### Check off the following

-   [ ] I have tested my changes with the current requirements
-   [ ] My Code follows the pep8 code style.
