### PR TITLE
:sparkles: Added 12 endpoints to `Channel`

### DIFF
--- a/examples/cooldowns.py
+++ b/examples/cooldowns.py
@@ -22,7 +22,7 @@ class Bot(Client):
         """
         Generate a valid random Discord color!
         """
-        return int(hex(randint(0, 16581375)), 0)
+        return randint(0, 16581375)
 
     async def get_meme(self) -> Tuple[str, str]:
         """

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any, AsyncIterator, overload, TYPE_CHECKING
 
-from pincer.objects.guild.thread import ThreadMember
-
 from .invite import Invite, InviteTargetType
 from ..message.user_message import UserMessage
 from ..._config import GatewayConfig
@@ -17,6 +15,7 @@ from ...utils.api_object import APIObject, GuildProperty
 from ...utils.conversion import construct_client_dict, remove_none
 from ...utils.convert_message import convert_message
 from ...utils.types import MISSING
+from ...objects import ThreadMember
 
 if TYPE_CHECKING:
     from typing import AsyncGenerator, Dict, List, Optional, Union

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 from asyncio import sleep, ensure_future
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, AsyncIterator, overload, TYPE_CHECKING
+from urllib.parse import urlencode
+from typing import AsyncIterator, overload, TYPE_CHECKING
 
 from .invite import Invite, InviteTargetType
 from ..message.user_message import UserMessage
@@ -676,12 +677,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.channel.ThreadsResponse`
             The response object.
         """
-        data = await self._http.get(
-            f"channels/{self.id}/threads/archived/public",
-            data=remove_none({"before": before, "limit": limit}),
-        )
         return ThreadsResponse.from_dict(
-            construct_client_dict(self._client, data)
+            construct_client_dict(
+                self._client,
+                await self._http.get(
+                    f"channels/{self.id}/threads/archived/public?"
+                    + urlencode(remove_none({"before": before, "limit": limit}))
+                ),
+            )
         )
 
     async def list_private_archived_threads(
@@ -707,12 +710,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.channel.ThreadsResponse`
             The response object.
         """
-        data = await self._http.get(
-            f"channels/{self.id}/threads/archived/private",
-            data=remove_none({"before": before, "limit": limit}),
-        )
         return ThreadsResponse.from_dict(
-            construct_client_dict(self._client, data)
+            construct_client_dict(
+                self._client,
+                await self._http.get(
+                    f"channels/{self.id}/threads/archived/private?"
+                    + urlencode(remove_none({"before": before, "limit": limit}))
+                ),
+            )
         )
 
     async def list_joined_private_archived_threads(
@@ -738,12 +743,15 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.channel.ThreadsResponse`
             The response object.
         """
-        data = self._http.get(
-            f"channels/{self.id}/users/@me/threads/archived/private",
-            data=remove_none({"before": before, "limit": limit}),
-        )
+
         return ThreadsResponse.from_dict(
-            construct_client_dict(self._client, data)
+            construct_client_dict(
+                self._client,
+                self._http.get(
+                    f"channels/{self.id}/users/@me/threads/archived/private?"
+                    + urlencode(remove_none({"before": before, "limit": limit}))
+                ),
+            )
         )
 
     def __str__(self):
@@ -1103,6 +1111,7 @@ class PrivateThread(Thread):
 @dataclass(repr=False)
 class ThreadsResponse(APIObject):
     """A class representing a response from the API for a list of threads."""
+
     threads: AsyncIterator[Thread]
     members: AsyncIterator[ThreadMember]
     has_more: bool

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -667,8 +667,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         self,
         message: UserMessage,
         name: str = None,
-        auto_archive_duration: int = None,
-        rate_limit_per_user: int = None,
+        auto_archive_duration: Optional[int] = None,
+        rate_limit_per_user: Optional[int] = None,
         reason: Optional[str] = None
     ) -> Channel:
         """
@@ -948,7 +948,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = self._http.get(
             f"channels/{self.id}/threads/archived/private",
-            data={"before": before, "limit": limit}
+            data=remove_none({"before": before, "limit": limit})
         )
         return {
             "threads": (Channel.from_dict(construct_client_dict(

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -683,7 +683,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        message: :class:`~.pincer.objects.message.user_message.UserMessage`
+        message: :class:`~pincer.objects.message.user_message.UserMessage`
             The message to create the thread from.
         name: Optional[:class:`str`]
             The name of the thread. 1-100 characters.
@@ -701,7 +701,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        :class:`~.pincer.objects.channel.Channel`
+        :class:`~pincer.objects.channel.Channel`
             The created thread.
         """
         return Channel.from_dict(construct_client_dict(self._client,
@@ -737,7 +737,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         auto_archive_duration**: Optional[:class:`int`]
             The duration in minutes to automatically archive the thread after
             recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
-        type_: Optional[:class:`~.pincer.objects.channel.ChannelType`]
+        type_: Optional[:class:`~pincer.objects.channel.ChannelType`]
             The type of thread to create.
         invitable: Optional[:class:`bool`]
             Whether non-moderators can add other non-moderators to a thread;
@@ -788,7 +788,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        user: :class:`~.pincer.objects.user.User`
+        user: :class:`~pincer.objects.user.User`
             The user to add to the thread.
         """
         await self._http.put(f"channels/{self.id}/thread-members/{user.id}")
@@ -808,7 +808,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        user: :class:`~.pincer.objects.user.User`
+        user: :class:`~pincer.objects.user.User`
             The user to remove from the thread.
         """
         await self._http.delete(f"channels/{self.id}/thread-members/{user.id}")
@@ -820,12 +820,12 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        user: :class:`~.pincer.objects.user.User`
+        user: :class:`~pincer.objects.user.User`
             The user to get the thread member for.
 
         Returns
         -------
-        :class:`~.pincer.objects.channel.ThreadMember`
+        :class:`~pincer.objects.channel.ThreadMember`
             The thread member object.
         """
         return ThreadMember.from_dict(construct_client_dict(self._client,
@@ -839,7 +839,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        AsyncIterator[:class:`~.pincer.objects.channel.ThreadMember`]
+        AsyncIterator[:class:`~pincer.objects.channel.ThreadMember`]
             An iterator of thread members.
         """
         data = await self._http.get(f"channels/{self.id}/thread-members")
@@ -848,14 +848,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
                 construct_client_dict(self._client, member)
             )
 
-    async def list_active_threads(self) -> dict[str, Any]:
+    async def list_active_threads(self) -> Dict[str, Any]:
         """
         Returns all active threads in the channel, including public and
         private threads. Threads are ordered by their id, in descending order.
 
         Returns
         -------
-        dict[:class:`str`, :class:`Any`]
+        Dict[:class:`str`, :class:`Any`]
             Dictionary containing the response body:
                 - threads: Generator of the active threads.
                 - members: Generator for each thread member object for each
@@ -878,7 +878,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         self,
         before: Timestamp = None,
         limit: int = None
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are public.
         When called on a ``GUILD_TEXT`` channel, returns threads of type
@@ -889,14 +889,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+        before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
 
         Returns
         -------
-        dict[:class:`str`, :class:`Any`]
+        Dict[:class:`str`, :class:`Any`]
             Dictionary containing the response body:
                 - threads: Generator of the public archived threads.
                 - members: Generator for each thread member object for each
@@ -922,7 +922,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         self,
         before: Timestamp = None,
         limit: int = None
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``. Threads are ordered by ``archive_timestamp``,
@@ -931,14 +931,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+        before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
 
         Returns
         -------
-        dict[:class:`str`, :class:`Any`]
+        Dict[:class:`str`, :class:`Any`]
             Dictionary containing the response body:
                 - threads: Generator of the private archived threads.
                 - members: Generator for each thread member object for each
@@ -964,7 +964,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         self,
         before: Timestamp = None,
         limit: int = None
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``, and the user has joined. Threads are ordered
@@ -973,14 +973,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Parameters
         ----------
-        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+        before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
 
         Returns
         -------
-        dict[:class:`str`, :class:`Any`]
+        Dict[:class:`str`, :class:`Any`]
             Dictionary containing the response body:
                 - threads: Generator of the private archived threads
                 the user has joined.

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -634,7 +634,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
     async def start_thread_with_message(
         self,
-        message: UserMessage,
+        message: Optional[UserMessage],
         name: Optional[str] = None,
         auto_archive_duration: Optional[int] = None,
         rate_limit_per_user: Optional[int] = None,
@@ -695,7 +695,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
     async def start_thread(
         self,
-        name: str = None,
+        name: Optional[str] = None,
         auto_archive_duration: Optional[int] = None,
         type_: Optional[ChannelType] = None,
         invitable: Optional[bool] = None,
@@ -899,7 +899,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = await self._http.get(
             f"channels/{self.id}/threads/archived/public",
-            data={"before": before, "limit": limit},
+            data=remove_none({"before": before, "limit": limit}),
         )
         return {
             "threads": (
@@ -988,7 +988,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = self._http.get(
             f"channels/{self.id}/users/@me/threads/archived/private",
-            data={"before": before, "limit": limit},
+            data=remove_none({"before": before, "limit": limit}),
         )
         return {
             "threads": (

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -73,11 +73,10 @@ class ChannelType(IntEnum):
 
     if GatewayConfig.version >= 9:
         GUILD_NEWS_THREAD = 10
-        GUILD_THREAD = 11
-        GUILD_PUBLIC_THREAD = 12
-        GUILD_PRIVATE_THREAD = 13
+        GUILD_PUBLIC_THREAD = 11
+        GUILD_PRIVATE_THREAD = 12
 
-    GUILD_STAGE_VOICE = 14
+    GUILD_STAGE_VOICE = 13
 
 
 @dataclass(repr=False)

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -62,6 +62,7 @@ class ChannelType(IntEnum):
     GUILD_STAGE_VOICE:
         A stage channel.
     """
+
     GUILD_TEXT = 0
     DM = 1
     GUILD_VOICE = 2
@@ -149,6 +150,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     video_quality_mode: APINullable[:class:`int`]
         The camera video quality mode of the voice channel, 1 when not present
     """
+
     # noqa: E501
     id: Snowflake
     type: ChannelType
@@ -210,10 +212,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = (await client.http.get(f"channels/{channel_id}")) or {}
 
-        data.update(construct_client_dict(
-            client,
-            {"type": ChannelType(data.pop("type"))}
-        ))
+        data.update(
+            construct_client_dict(
+                client, {"type": ChannelType(data.pop("type"))}
+            )
+        )
 
         channel_cls = _channel_type_map.get(data["type"], Channel)
         return channel_cls.from_dict(data)
@@ -234,15 +237,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         parent_id: Snowflake = None,
         rtc_region: str = None,
         video_quality_mod: int = None,
-        default_auto_archive_duration: int = None
+        default_auto_archive_duration: int = None,
     ) -> Channel:
         ...
 
-    async def edit(
-        self,
-        reason: Optional[str] = None,
-        **kwargs
-    ):
+    async def edit(self, reason: Optional[str] = None, **kwargs):
         """Edit a channel with the given keyword arguments.
 
         Parameters
@@ -263,14 +262,13 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             headers["X-Audit-Log-Reason"] = str(reason)
 
         data = await self._http.patch(
-            f"channels/{self.id}",
-            kwargs,
-            headers=headers
+            f"channels/{self.id}", kwargs, headers=headers
         )
-        data.update(construct_client_dict(
-            self._client,
-            {"type": ChannelType(data.pop("type"))}
-        ))
+        data.update(
+            construct_client_dict(
+                self._client, {"type": ChannelType(data.pop("type"))}
+            )
+        )
         channel_cls = _channel_type_map.get(data["type"], Channel)
         return channel_cls.from_dict(data)
 
@@ -280,7 +278,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         allow: str,
         deny: str,
         type: int,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
     ):
         """
         Edit the channel permission overwrites for a user or role in a channel.
@@ -304,17 +302,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         await self._http.put(
             f"channels/{self.id}/permissions/{overwrite.id}",
             headers=remove_none({"X-Audit-Log-Reason": reason}),
-            data={
-                "allow": allow,
-                "deny": deny,
-                "type": type
-            }
+            data={"allow": allow, "deny": deny, "type": type},
         )
 
     async def delete_permission(
-        self,
-        overwrite: Overwrite,
-        reason: Optional[str] = None
+        self, overwrite: Overwrite, reason: Optional[str] = None
     ):
         """
         Delete a channel permission overwrite for a user or role in a channel.
@@ -333,8 +325,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def follow_news_channel(
-        self,
-        webhook_channel_id: Snowflake
+        self, webhook_channel_id: Snowflake
     ) -> NewsChannel:
         """
         Follow a News Channel to send messages to a target channel.
@@ -356,8 +347,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
                 self._client,
                 self._http.post(
                     f"channels/{self.id}/followers",
-                    data={"webhook_channel_id": webhook_channel_id}
-                )
+                    data={"webhook_channel_id": webhook_channel_id},
+                ),
             )
         )
 
@@ -384,16 +375,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         data = await self._http.get(f"channels/{self.id}/pins")
         for message in data:
             yield UserMessage.from_dict(
-                construct_client_dict(
-                    self._client,
-                    message
-                )
+                construct_client_dict(self._client, message)
             )
 
     async def pin_message(
-        self,
-        message: UserMessage,
-        reason: Optional[str] = None
+        self, message: UserMessage, reason: Optional[str] = None
     ):
         """
         Pin a message in a channel. Requires the ``MANAGE_MESSAGES`` permission.
@@ -405,9 +391,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def unpin_message(
-        self,
-        message: UserMessage,
-        reason: Optional[str] = None
+        self, message: UserMessage, reason: Optional[str] = None
     ):
         """
         Unpin a message in a channel. Requires the ``MANAGE_MESSAGES`` permission.
@@ -421,7 +405,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         self,
         user: User,
         access_token: Optional[str] = None,
-        nick: Optional[str] = None
+        nick: Optional[str] = None,
     ):
         """
         Adds a recipient to a Group DM using their access token.
@@ -438,16 +422,10 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.put(
             f"channels/{self.id}/recipients/{user.id}",
-            data={
-                "access_token": access_token,
-                "nick": nick
-            }
+            data={"access_token": access_token, "nick": nick},
         )
 
-    async def group_dm_remove_recipient(
-        self,
-        user: User
-    ):
+    async def group_dm_remove_recipient(self, user: User):
         """
         Removes a recipient from a Group DM.
 
@@ -456,14 +434,10 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         user: :class:`~pincer.objects.user.User`
             The user to remove.
         """
-        await self._http.delete(
-            f"channels/{self.id}/recipients/{user.id}"
-        )
+        await self._http.delete(f"channels/{self.id}/recipients/{user.id}")
 
     async def bulk_delete_messages(
-        self,
-        messages: List[Snowflake],
-        reason: Optional[str] = None
+        self, messages: List[Snowflake], reason: Optional[str] = None
     ):
         """Delete multiple messages in a single request.
         This endpoint can only be used on guild channels and requires
@@ -483,14 +457,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         await self._http.post(
             f"channels/{self.id}/messages/bulk_delete",
             headers=remove_none({"X-Audit-Log-Reason": reason}),
-            data={"messages": messages}
+            data={"messages": messages},
         )
 
     async def delete(
         self,
         reason: Optional[str] = None,
         /,
-        channel_id: Optional[Snowflake] = None
+        channel_id: Optional[Snowflake] = None,
     ):
         """|coro|
 
@@ -507,7 +481,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         await self._http.delete(
             f"channels/{channel_id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers=remove_none({"X-Audit-Log-Reason": reason}),
         )
 
     async def __post_send_handler(self, message: UserMessage):
@@ -523,10 +497,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             await sleep(message.delete_after)
             await message.delete()
 
-    def __post_sent(
-        self,
-        message: UserMessage
-    ):
+    def __post_sent(self, message: UserMessage):
         """Ensure the `__post_send_handler` method its future.
 
         Parameters
@@ -554,9 +525,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         content_type, data = convert_message(self._client, message).serialize()
 
         resp = await self._http.post(
-            f"channels/{self.id}/messages",
-            data,
-            content_type=content_type
+            f"channels/{self.id}/messages", data, content_type=content_type
         )
         msg = UserMessage.from_dict(resp)
         self.__post_sent(msg)
@@ -574,10 +543,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         data = await self._http.get(f"channels/{self.id}/webhooks")
         for webhook_data in data:
             yield Webhook.from_dict(
-                construct_client_dict(
-                    self._client,
-                    webhook_data
-                )
+                construct_client_dict(self._client, webhook_data)
             )
 
     async def get_invites(self) -> AsyncIterator[Invite]:
@@ -603,7 +569,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         target_type: InviteTargetType = None,
         target_user_id: Snowflake = None,
         target_application_id: Snowflake = None,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
     ):
         """
         Create a new invite object for the channel. Only usable for guild
@@ -647,29 +613,32 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.guild.invite.Invite`
             The invite object.
         """
-        return Invite.from_dict(construct_client_dict(self._client,
-            await self._http.post(
-                f"channels/{self.id}/invites",
-                headers=remove_none({"X-Audit-Log-Reason": reason}),
-                data={
-                    "max_age": max_age,
-                    "max_uses": max_uses,
-                    "temporary": temporary,
-                    "unique": unique,
-                    "target_type": target_type,
-                    "target_user_id": target_user_id,
-                    "target_application_id": target_application_id
-                }
+        return Invite.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(
+                    f"channels/{self.id}/invites",
+                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    data={
+                        "max_age": max_age,
+                        "max_uses": max_uses,
+                        "temporary": temporary,
+                        "unique": unique,
+                        "target_type": target_type,
+                        "target_user_id": target_user_id,
+                        "target_application_id": target_application_id,
+                    },
+                ),
             )
-        ))
+        )
 
     async def start_thread_with_message(
         self,
         message: UserMessage,
-        name: str = Optional[None],
+        name: Optional[str] = None,
         auto_archive_duration: Optional[int] = None,
         rate_limit_per_user: Optional[int] = None,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
     ) -> Channel:
         """
         Creates a new thread from an existing message. Returns a Channel on
@@ -704,17 +673,20 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.channel.Channel`
             The created thread.
         """
-        return Channel.from_dict(construct_client_dict(self._client,
-            await self._http.post(
-                f"channels/{self.id}/messages/{message.id}/threads",
-                headers=remove_none({"X-Audit-Log-Reason": reason}),
-                data={
-                    "name": name,
-                    "auto_archive_duration": auto_archive_duration,
-                    "rate_limit_per_user": rate_limit_per_user
-                }
+        return Channel.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(
+                    f"channels/{self.id}/messages/{message.id}/threads",
+                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    data={
+                        "name": name,
+                        "auto_archive_duration": auto_archive_duration,
+                        "rate_limit_per_user": rate_limit_per_user,
+                    },
+                ),
             )
-        ))
+        )
 
     async def start_thread(
         self,
@@ -723,7 +695,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         type_: Optional[ChannelType] = None,
         invitable: Optional[bool] = None,
         rate_limit_per_user: Optional[int] = None,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
     ) -> Channel:
         """
         Creates a new thread that is not connected to an existing message.
@@ -759,19 +731,22 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~.pincer.objects.channel.Channel`
             The created thread.
         """
-        return Channel.from_dict(construct_client_dict(self._client,
-            await self._http.post(
-                f"channels/{self.id}/threads",
-                headers=remove_none({"X-Audit-Log-Reason": reason}),
-                data={
-                    "name": name,
-                    "auto_archive_duration": auto_archive_duration,
-                    "type": type_,
-                    "invitable": invitable,
-                    "rate_limit_per_user": rate_limit_per_user
-                }
+        return Channel.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(
+                    f"channels/{self.id}/threads",
+                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    data={
+                        "name": name,
+                        "auto_archive_duration": auto_archive_duration,
+                        "type": type_,
+                        "invitable": invitable,
+                        "rate_limit_per_user": rate_limit_per_user,
+                    },
+                ),
             )
-        ))
+        )
 
     async def join_thread(self):
         """
@@ -828,9 +803,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         :class:`~pincer.objects.channel.ThreadMember`
             The thread member object.
         """
-        return ThreadMember.from_dict(construct_client_dict(self._client,
-            await self._http.get(f"channels/{self.id}/thread-members/{user.id}")
-        ))
+        return ThreadMember.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.get(
+                    f"channels/{self.id}/thread-members/{user.id}"
+                ),
+            )
+        )
 
     async def list_thread_members(self) -> AsyncIterator[ThreadMember]:
         """
@@ -865,19 +845,19 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = self._http.get(f"channels/{self.id}/threads/active")
         return {
-            "threads": (Channel.from_dict(construct_client_dict(
-                self._client, t
-            )) for t in data["threads"]),
-            "members": (ThreadMember.from_dict(construct_client_dict(
-                self._client, m
-            )) for m in data["members"]),
-            "has_more": data["has_more"]
+            "threads": (
+                Channel.from_dict(construct_client_dict(self._client, t))
+                for t in data["threads"]
+            ),
+            "members": (
+                ThreadMember.from_dict(construct_client_dict(self._client, m))
+                for m in data["members"]
+            ),
+            "has_more": data["has_more"],
         }
 
     async def list_public_archived_threads(
-        self,
-        before: Optional[Timestamp] = None,
-        limit: Optional[int] = None
+        self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are public.
@@ -906,22 +886,22 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = await self._http.get(
             f"channels/{self.id}/threads/archived/public",
-            data={"before": before, "limit": limit}
+            data={"before": before, "limit": limit},
         )
         return {
-            "threads": (Channel.from_dict(construct_client_dict(
-                self._client, t
-            )) for t in data["threads"]),
-            "members": (ThreadMember.from_dict(construct_client_dict(
-                self._client, m
-            )) for m in data["members"]),
-            "has_more": data["has_more"]
+            "threads": (
+                Channel.from_dict(construct_client_dict(self._client, t))
+                for t in data["threads"]
+            ),
+            "members": (
+                ThreadMember.from_dict(construct_client_dict(self._client, m))
+                for m in data["members"]
+            ),
+            "has_more": data["has_more"],
         }
 
     async def list_private_archived_threads(
-        self,
-        before: Optional[Timestamp] = None,
-        limit: Optional[int] = None
+        self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are of type
@@ -948,22 +928,22 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = await self._http.get(
             f"channels/{self.id}/threads/archived/private",
-            data=remove_none({"before": before, "limit": limit})
+            data=remove_none({"before": before, "limit": limit}),
         )
         return {
-            "threads": (Channel.from_dict(construct_client_dict(
-                self._client, t
-            )) for t in data["threads"]),
-            "members": (ThreadMember.from_dict(construct_client_dict(
-                self._client, m
-            )) for m in data["members"]),
-            "has_more": data["has_more"]
+            "threads": (
+                Channel.from_dict(construct_client_dict(self._client, t))
+                for t in data["threads"]
+            ),
+            "members": (
+                ThreadMember.from_dict(construct_client_dict(self._client, m))
+                for m in data["members"]
+            ),
+            "has_more": data["has_more"],
         }
 
     async def list_joined_private_archived_threads(
-        self,
-        before: Optional[Timestamp] = None,
-        limit: Optional[int] = None
+        self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
         """
         Returns archived threads in the channel that are of type
@@ -991,18 +971,19 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         data = self._http.get(
             f"channels/{self.id}/users/@me/threads/archived/private",
-            data={"before": before, "limit": limit}
+            data={"before": before, "limit": limit},
         )
         return {
-            "threads": (Channel.from_dict(construct_client_dict(
-                self._client, t
-            )) for t in data["threads"]),
-            "members": (ThreadMember.from_dict(construct_client_dict(
-                self._client, m
-            )) for m in data["members"]),
-            "has_more": data["has_more"]
+            "threads": (
+                Channel.from_dict(construct_client_dict(self._client, t))
+                for t in data["threads"]
+            ),
+            "members": (
+                ThreadMember.from_dict(construct_client_dict(self._client, m))
+                for m in data["members"]
+            ),
+            "has_more": data["has_more"],
         }
-
 
     def __str__(self):
         """return the discord tag when object gets used as a string."""
@@ -1023,7 +1004,7 @@ class TextChannel(Channel):
         rate_limit_per_user: int = None,
         permissions_overwrites: List[Overwrite] = None,
         parent_id: Snowflake = None,
-        default_auto_archive_duration: int = None
+        default_auto_archive_duration: int = None,
     ) -> Union[TextChannel, NewsChannel]:
         ...
 
@@ -1057,9 +1038,7 @@ class TextChannel(Channel):
             The requested message.
         """
         return UserMessage.from_dict(
-            await self._http.get(
-                f"channels/{self.id}/messages/{message_id}"
-            )
+            await self._http.get(f"channels/{self.id}/messages/{message_id}")
         )
 
 
@@ -1075,7 +1054,7 @@ class VoiceChannel(Channel):
         user_limit: int = None,
         permissions_overwrites: List[Overwrite] = None,
         rtc_region: str = None,
-        video_quality_mod: int = None
+        video_quality_mod: int = None,
     ) -> VoiceChannel:
         ...
 
@@ -1094,13 +1073,16 @@ class VoiceChannel(Channel):
         """
         return await super().edit(**kwargs)
 
+
 class GroupDMChannel(Channel):
     """A subclass of ``Channel`` for Group DMs"""
+
 
 class CategoryChannel(Channel):
     """A subclass of ``Channel`` for categories channels
     with all the same attributes.
     """
+
     pass
 
 
@@ -1117,7 +1099,7 @@ class NewsChannel(Channel):
         nsfw: bool = None,
         permissions_overwrites: List[Overwrite] = None,
         parent_id: Snowflake = None,
-        default_auto_archive_duration: int = None
+        default_auto_archive_duration: int = None,
     ) -> Union[TextChannel, NewsChannel]:
         ...
 
@@ -1160,6 +1142,7 @@ class ChannelMention(APIObject):
     name: :class:`str`
         The name of the channel
     """
+
     id: Snowflake
     guild_id: Snowflake
     type: ChannelType
@@ -1174,5 +1157,5 @@ _channel_type_map: Dict[ChannelType, Channel] = {
     ChannelType.GUILD_CATEGORY: CategoryChannel,
     ChannelType.GUILD_NEWS: NewsChannel,
     ChannelType.GUILD_PUBLIC_THREAD: PublicThread,
-    ChannelType.GUILD_PRIVATE_THREAD: PrivateThread
+    ChannelType.GUILD_PRIVATE_THREAD: PrivateThread,
 }

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -742,7 +742,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        :class:`~.pincer.objects.channel.Channel`
+        :class:`~pincer.objects.channel.Channel`
             The created thread.
         """
         return Channel.from_dict(

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -1137,7 +1137,6 @@ _channel_type_map: Dict[ChannelType, Channel] = {
     ChannelType.GROUP_DM: GroupDMChannel,
     ChannelType.GUILD_CATEGORY: CategoryChannel,
     ChannelType.GUILD_NEWS: NewsChannel,
-    ChannelType.GUILD_THREAD: Thread,
     ChannelType.GUILD_PUBLIC_THREAD: PublicThread,
     ChannelType.GUILD_PRIVATE_THREAD: PrivateThread,
 }

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -547,7 +547,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             )
 
     async def get_invites(self) -> AsyncIterator[Invite]:
-        """
+        """|coro|
         Fetches all the invite objects for the channel. Only usable for
         guild channels. Requires the ``MANAGE_CHANNELS`` permission.
 
@@ -571,7 +571,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         target_application_id: Snowflake = None,
         reason: Optional[str] = None,
     ):
-        """
+        """|coro|
         Create a new invite object for the channel. Only usable for guild
         channels. Requires the ``CREATE_INSTANT_INVITE`` permission.
 
@@ -640,7 +640,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         rate_limit_per_user: Optional[int] = None,
         reason: Optional[str] = None,
     ) -> Channel:
-        """
+        """|coro|
         Creates a new thread from an existing message. Returns a Channel on
         success.
 
@@ -654,16 +654,21 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ----------
         message: :class:`~pincer.objects.message.user_message.UserMessage`
             The message to create the thread from.
+            |default| data:`None`
         name: Optional[:class:`str`]
             The name of the thread. 1-100 characters.
+            |default| data:`None`
         auto_archive_duration: Optional[:class:`int`]
             The duration in minutes to automatically archive the thread after
             recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
+            |default| data:`None`
         rate_limit_per_user: Optional[:class:`int`]
-            Amount of seconds a user has to wait before sending another message
+            Amount of seconds a user has to wait before sending another message.
             (0-21600)
+            |default| data:`None`
         reason: Optional[:class:`str`]
             The reason of the thread creation.
+            |default| data:`None`
 
         The 3 day and 7 day archive durations require the server to be boosted.
         The guild features will indicate if a server is able to use those settings.
@@ -697,7 +702,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         rate_limit_per_user: Optional[int] = None,
         reason: Optional[str] = None,
     ) -> Channel:
-        """
+        """|coro|
         Creates a new thread that is not connected to an existing message.
         The created thread defaults to a ``GUILD_PRIVATE_THREAD``*.
         Returns a Channel on success.
@@ -706,19 +711,25 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ----------
         name: Optional[:class:`str`]
             The name of the thread. 1-100 characters.
+            |default| :data:`None`
         auto_archive_duration**: Optional[:class:`int`]
             The duration in minutes to automatically archive the thread after
             recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
+            |default| :data:`None`
         type_: Optional[:class:`~pincer.objects.channel.ChannelType`]
             The type of thread to create.
+            |default| :data:`None`
         invitable: Optional[:class:`bool`]
             Whether non-moderators can add other non-moderators to a thread;
             only available when creating a private thread.
+            |default| :data:`None`
         rate_limit_per_user: Optional[:class:`int`]
             Amount of seconds a user has to wait before sending another message.
             (0-21600)
+            |default| :data:`None`
         reason: Optional[:class:`str`]
             The reason of the thread creation.
+            |default| :data:`None`
 
         \\*: Creating a private thread requires the server to be boosted.
         The guild features will indicate if that is possible for the guild.
@@ -749,14 +760,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def join_thread(self):
-        """
+        """|coro|
         Adds the current user to a thread.
         Also requires the thread to not be archived.
         """
         await self._http.put(f"channels/{self.id}/thread-members/@me")
 
     async def add_thread_member(self, user: User):
-        """
+        """|coro|
         Adds another member to a thread.
         Requires the ability to send messages in the thread.
         Also requires the thread to not be archived.
@@ -769,14 +780,14 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         await self._http.put(f"channels/{self.id}/thread-members/{user.id}")
 
     async def leave_thread(self):
-        """
+        """|coro|
         Removes the current user from a thread.
         Also requires the thread to not be archived.
         """
         await self._http.delete(f"channels/{self.id}/thread-members/@me")
 
     async def remove_thread_member(self, user: User):
-        """
+        """|coro|
         Removes another member from a thread. Requires the ``MANAGE_THREADS``
         permission, or the creator of the thread if it is a
         ``GUILD_PRIVATE_THREAD``. Also requires the thread to not be archived.
@@ -789,7 +800,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         await self._http.delete(f"channels/{self.id}/thread-members/{user.id}")
 
     async def get_thread_member(self, user: User) -> ThreadMember:
-        """
+        """|coro|
         Returns a thread member object for the specified user if they are a
         member of the thread.
 
@@ -813,7 +824,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def list_thread_members(self) -> AsyncIterator[ThreadMember]:
-        """
+        """|coro|
         Fetches all the thread members for the thread. Returns an iterator of
         ThreadMember objects.
 
@@ -829,7 +840,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             )
 
     async def list_active_threads(self) -> Dict[str, Any]:
-        """
+        """|coro|
         Returns all active threads in the channel, including public and
         private threads. Threads are ordered by their id, in descending order.
 
@@ -859,7 +870,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def list_public_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
-        """
+        """|coro|
         Returns archived threads in the channel that are public.
         When called on a ``GUILD_TEXT`` channel, returns threads of type
         ``GUILD_PUBLIC_THREAD``. When called on a ``GUILD_NEWS`` channel returns
@@ -871,8 +882,10 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ----------
         before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
+            |default| :data:`None`
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
+            |default| :data:`None`
 
         Returns
         -------
@@ -903,7 +916,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def list_private_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
-        """
+        """|coro|
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``. Threads are ordered by ``archive_timestamp``,
         in descending order. Requires both the ``READ_MESSAGE_HISTORY`` and
@@ -913,8 +926,10 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ----------
         before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
+            |default| :data:`None`
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
+            |default| :data:`None`
 
         Returns
         -------
@@ -945,7 +960,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def list_joined_private_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
     ) -> Dict[str, Any]:
-        """
+        """|coro|
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``, and the user has joined. Threads are ordered
         by their id, in descending order. Requires the ``READ_MESSAGE_HISTORY``
@@ -955,8 +970,10 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ----------
         before: Optional[:class:`~pincer.objects.timestamp.Timestamp`]
             Returns threads before this timestamp.
+            |default| :data:`None`
         limit: Optional[:class:`int`]
             The maximum number of threads to return.
+            |default| :data:`None`
 
         Returns
         -------

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -848,6 +848,162 @@ class Channel(APIObject, GuildProperty):  # noqa E501
                 construct_client_dict(self._client, member)
             )
 
+    async def list_active_threads(self) -> dict[str, Any]:
+        """
+        Returns all active threads in the channel, including public and
+        private threads. Threads are ordered by their id, in descending order.
+
+        Returns
+        -------
+        dict[:class:`str`, :class:`Any`]
+            Dictionary containing the response body:
+                - threads: Generator of the active threads.
+                - members: Generator for each thread member object for each
+                returned thread the current user has joined.
+                - has_more: Whether there are potentially additional threads
+                that could be returned on a subsequent call.
+        """
+        data = self._http.get(f"channels/{self.id}/threads/active")
+        return {
+            "threads": (Channel.from_dict(construct_client_dict(
+                self._client, t
+            )) for t in data["threads"]),
+            "members": (ThreadMember.from_dict(construct_client_dict(
+                self._client, m
+            )) for m in data["members"]),
+            "has_more": data["has_more"]
+        }
+
+    async def list_public_archived_threads(
+        self,
+        before: Timestamp = None,
+        limit: int = None
+    ) -> dict[str, Any]:
+        """
+        Returns archived threads in the channel that are public.
+        When called on a ``GUILD_TEXT`` channel, returns threads of type
+        ``GUILD_PUBLIC_THREAD``. When called on a ``GUILD_NEWS`` channel returns
+        threads of type ``GUILD_NEWS_THREAD``. Threads are ordered by
+        ``archive_timestamp``, in descending order. Requires the
+        ``READ_MESSAGE_HISTORY`` permission.
+
+        Parameters
+        ----------
+        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+            Returns threads before this timestamp.
+        limit: Optional[:class:`int`]
+            The maximum number of threads to return.
+
+        Returns
+        -------
+        dict[:class:`str`, :class:`Any`]
+            Dictionary containing the response body:
+                - threads: Generator of the public archived threads.
+                - members: Generator for each thread member object for each
+                returned thread the current user has joined.
+                - has_more: Whether there are potentially additional threads
+                that could be returned on a subsequent call.
+        """
+        data = self._http.get(
+            f"channels/{self.id}/threads/archived/public",
+            data={"before": before, "limit": limit}
+        )
+        return {
+            "threads": (Channel.from_dict(construct_client_dict(
+                self._client, t
+            )) for t in data["threads"]),
+            "members": (ThreadMember.from_dict(construct_client_dict(
+                self._client, m
+            )) for m in data["members"]),
+            "has_more": data["has_more"]
+        }
+
+    async def list_private_archived_threads(
+        self,
+        before: Timestamp = None,
+        limit: int = None
+    ) -> dict[str, Any]:
+        """
+        Returns archived threads in the channel that are of type
+        ``GUILD_PRIVATE_THREAD``. Threads are ordered by ``archive_timestamp``,
+        in descending order. Requires both the ``READ_MESSAGE_HISTORY`` and
+        ``MANAGE_THREADS`` permissions.
+
+        Parameters
+        ----------
+        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+            Returns threads before this timestamp.
+        limit: Optional[:class:`int`]
+            The maximum number of threads to return.
+
+        Returns
+        -------
+        dict[:class:`str`, :class:`Any`]
+            Dictionary containing the response body:
+                - threads: Generator of the private archived threads.
+                - members: Generator for each thread member object for each
+                returned thread the current user has joined.
+                - has_more: Whether there are potentially additional threads
+                that could be returned on a subsequent call.
+        """
+        data = self._http.get(
+            f"channels/{self.id}/threads/archived/private",
+            data={"before": before, "limit": limit}
+        )
+        return {
+            "threads": (Channel.from_dict(construct_client_dict(
+                self._client, t
+            )) for t in data["threads"]),
+            "members": (ThreadMember.from_dict(construct_client_dict(
+                self._client, m
+            )) for m in data["members"]),
+            "has_more": data["has_more"]
+        }
+
+    async def list_joined_private_archived_threads(
+        self,
+        before: Timestamp = None,
+        limit: int = None
+    ) -> dict[str, Any]:
+        """
+        Returns archived threads in the channel that are of type
+        ``GUILD_PRIVATE_THREAD``, and the user has joined. Threads are ordered
+        by their id, in descending order. Requires the ``READ_MESSAGE_HISTORY``
+        permission.
+
+        Parameters
+        ----------
+        before: Optional[:class:`~.pincer.objects.timestamp.Timestamp`]
+            Returns threads before this timestamp.
+        limit: Optional[:class:`int`]
+            The maximum number of threads to return.
+
+        Returns
+        -------
+        dict[:class:`str`, :class:`Any`]
+            Dictionary containing the response body:
+                - threads: Generator of the private archived threads
+                the user has joined.
+                - members: Generator for each thread member object for each
+                returned thread the current user has joined.
+                - has_more: Whether there are potentially additional threads
+                that could be returned on a subsequent call.
+        """
+        data = self._http.get(
+            f"channels/{self.id}/users/@me/threads/archived/private",
+            data={"before": before, "limit": limit}
+        )
+        return {
+            "threads": (Channel.from_dict(construct_client_dict(
+                self._client, t
+            )) for t in data["threads"]),
+            "members": (ThreadMember.from_dict(construct_client_dict(
+                self._client, m
+            )) for m in data["members"]),
+            "has_more": data["has_more"]
+        }
+
+
     def __str__(self):
         """return the discord tag when object gets used as a string."""
         return self.name or str(self.id)

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -695,152 +695,6 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             )
         )
 
-    async def start_thread(
-        self,
-        name: Optional[str] = None,
-        auto_archive_duration: Optional[int] = None,
-        type_: Optional[ChannelType] = None,
-        invitable: Optional[bool] = None,
-        rate_limit_per_user: Optional[int] = None,
-        reason: Optional[str] = None,
-    ) -> Channel:
-        """|coro|
-        Creates a new thread that is not connected to an existing message.
-        The created thread defaults to a ``GUILD_PRIVATE_THREAD``*.
-        Returns a Channel on success.
-
-        Parameters
-        ----------
-        name: Optional[:class:`str`]
-            The name of the thread. 1-100 characters.
-            |default| :data:`None`
-        auto_archive_duration**: Optional[:class:`int`]
-            The duration in minutes to automatically archive the thread after
-            recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
-            |default| :data:`None`
-        type_: Optional[:class:`~pincer.objects.channel.ChannelType`]
-            The type of thread to create.
-            |default| :data:`None`
-        invitable: Optional[:class:`bool`]
-            Whether non-moderators can add other non-moderators to a thread;
-            only available when creating a private thread.
-            |default| :data:`None`
-        rate_limit_per_user: Optional[:class:`int`]
-            Amount of seconds a user has to wait before sending another message.
-            (0-21600)
-            |default| :data:`None`
-        reason: Optional[:class:`str`]
-            The reason of the thread creation.
-            |default| :data:`None`
-
-        \\*: Creating a private thread requires the server to be boosted.
-        The guild features will indicate if that is possible for the guild.
-
-        \\*\\*: The 3 day and 7 day archive durations require the server to be boosted.
-        The guild features will indicate if that is possible for the guild.
-
-        Returns
-        -------
-        :class:`~pincer.objects.channel.Channel`
-            The created thread.
-        """
-        return Channel.from_dict(
-            construct_client_dict(
-                self._client,
-                await self._http.post(
-                    f"channels/{self.id}/threads",
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
-                    data={
-                        "name": name,
-                        "auto_archive_duration": auto_archive_duration,
-                        "type": type_,
-                        "invitable": invitable,
-                        "rate_limit_per_user": rate_limit_per_user,
-                    },
-                ),
-            )
-        )
-
-    async def join_thread(self):
-        """|coro|
-        Adds the current user to a thread.
-        Also requires the thread to not be archived.
-        """
-        await self._http.put(f"channels/{self.id}/thread-members/@me")
-
-    async def add_thread_member(self, user: User):
-        """|coro|
-        Adds another member to a thread.
-        Requires the ability to send messages in the thread.
-        Also requires the thread to not be archived.
-
-        Parameters
-        ----------
-        user: :class:`~pincer.objects.user.User`
-            The user to add to the thread.
-        """
-        await self._http.put(f"channels/{self.id}/thread-members/{user.id}")
-
-    async def leave_thread(self):
-        """|coro|
-        Removes the current user from a thread.
-        Also requires the thread to not be archived.
-        """
-        await self._http.delete(f"channels/{self.id}/thread-members/@me")
-
-    async def remove_thread_member(self, user: User):
-        """|coro|
-        Removes another member from a thread. Requires the ``MANAGE_THREADS``
-        permission, or the creator of the thread if it is a
-        ``GUILD_PRIVATE_THREAD``. Also requires the thread to not be archived.
-
-        Parameters
-        ----------
-        user: :class:`~pincer.objects.user.User`
-            The user to remove from the thread.
-        """
-        await self._http.delete(f"channels/{self.id}/thread-members/{user.id}")
-
-    async def get_thread_member(self, user: User) -> ThreadMember:
-        """|coro|
-        Returns a thread member object for the specified user if they are a
-        member of the thread.
-
-        Parameters
-        ----------
-        user: :class:`~pincer.objects.user.User`
-            The user to get the thread member for.
-
-        Returns
-        -------
-        :class:`~pincer.objects.channel.ThreadMember`
-            The thread member object.
-        """
-        return ThreadMember.from_dict(
-            construct_client_dict(
-                self._client,
-                await self._http.get(
-                    f"channels/{self.id}/thread-members/{user.id}"
-                ),
-            )
-        )
-
-    async def list_thread_members(self) -> AsyncIterator[ThreadMember]:
-        """|coro|
-        Fetches all the thread members for the thread. Returns an iterator of
-        ThreadMember objects.
-
-        Returns
-        -------
-        AsyncIterator[:class:`~pincer.objects.channel.ThreadMember`]
-            An iterator of thread members.
-        """
-        data = await self._http.get(f"channels/{self.id}/thread-members")
-        for member in data:
-            yield ThreadMember.from_dict(
-                construct_client_dict(self._client, member)
-            )
-
     async def list_active_threads(self) -> ThreadsResponse:
         """|coro|
         Returns all active threads in the channel, including public and
@@ -1090,6 +944,152 @@ class NewsChannel(Channel):
 
 class Thread(Channel):
     """A subclass of ``Channel`` for threads with all the same attributes."""
+
+    async def start(
+        self,
+        name: Optional[str] = None,
+        auto_archive_duration: Optional[int] = None,
+        type_: Optional[ChannelType] = None,
+        invitable: Optional[bool] = None,
+        rate_limit_per_user: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> Channel:
+        """|coro|
+        Creates a new thread that is not connected to an existing message.
+        The created thread defaults to a ``GUILD_PRIVATE_THREAD``*.
+        Returns a Channel on success.
+
+        Parameters
+        ----------
+        name: Optional[:class:`str`]
+            The name of the thread. 1-100 characters.
+            |default| :data:`None`
+        auto_archive_duration**: Optional[:class:`int`]
+            The duration in minutes to automatically archive the thread after
+            recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
+            |default| :data:`None`
+        type_: Optional[:class:`~pincer.objects.channel.ChannelType`]
+            The type of thread to create.
+            |default| :data:`None`
+        invitable: Optional[:class:`bool`]
+            Whether non-moderators can add other non-moderators to a thread;
+            only available when creating a private thread.
+            |default| :data:`None`
+        rate_limit_per_user: Optional[:class:`int`]
+            Amount of seconds a user has to wait before sending another message.
+            (0-21600)
+            |default| :data:`None`
+        reason: Optional[:class:`str`]
+            The reason of the thread creation.
+            |default| :data:`None`
+
+        \\*: Creating a private thread requires the server to be boosted.
+        The guild features will indicate if that is possible for the guild.
+
+        \\*\\*: The 3 day and 7 day archive durations require the server to be boosted.
+        The guild features will indicate if that is possible for the guild.
+
+        Returns
+        -------
+        :class:`~pincer.objects.channel.Channel`
+            The created thread.
+        """
+        return Channel.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(
+                    f"channels/{self.id}/threads",
+                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    data={
+                        "name": name,
+                        "auto_archive_duration": auto_archive_duration,
+                        "type": type_,
+                        "invitable": invitable,
+                        "rate_limit_per_user": rate_limit_per_user,
+                    },
+                ),
+            )
+        )
+
+    async def join(self):
+        """|coro|
+        Adds the current user to a thread.
+        Also requires the thread to not be archived.
+        """
+        await self._http.put(f"channels/{self.id}/thread-members/@me")
+
+    async def add_member(self, user: User):
+        """|coro|
+        Adds another member to a thread.
+        Requires the ability to send messages in the thread.
+        Also requires the thread to not be archived.
+
+        Parameters
+        ----------
+        user: :class:`~pincer.objects.user.User`
+            The user to add to the thread.
+        """
+        await self._http.put(f"channels/{self.id}/thread-members/{user.id}")
+
+    async def leave(self):
+        """|coro|
+        Removes the current user from a thread.
+        Also requires the thread to not be archived.
+        """
+        await self._http.delete(f"channels/{self.id}/thread-members/@me")
+
+    async def remove_member(self, user: User):
+        """|coro|
+        Removes another member from a thread. Requires the ``MANAGE_THREADS``
+        permission, or the creator of the thread if it is a
+        ``GUILD_PRIVATE_THREAD``. Also requires the thread to not be archived.
+
+        Parameters
+        ----------
+        user: :class:`~pincer.objects.user.User`
+            The user to remove from the thread.
+        """
+        await self._http.delete(f"channels/{self.id}/thread-members/{user.id}")
+
+    async def get_member(self, user: User) -> ThreadMember:
+        """|coro|
+        Returns a thread member object for the specified user if they are a
+        member of the thread.
+
+        Parameters
+        ----------
+        user: :class:`~pincer.objects.user.User`
+            The user to get the thread member for.
+
+        Returns
+        -------
+        :class:`~pincer.objects.channel.ThreadMember`
+            The thread member object.
+        """
+        return ThreadMember.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.get(
+                    f"channels/{self.id}/thread-members/{user.id}"
+                ),
+            )
+        )
+
+    async def list_members(self) -> AsyncIterator[ThreadMember]:
+        """|coro|
+        Fetches all the thread members for the thread. Returns an iterator of
+        ThreadMember objects.
+
+        Returns
+        -------
+        AsyncIterator[:class:`~pincer.objects.channel.ThreadMember`]
+            An iterator of thread members.
+        """
+        data = await self._http.get(f"channels/{self.id}/thread-members")
+        for member in data:
+            yield ThreadMember.from_dict(
+                construct_client_dict(self._client, member)
+            )
 
 
 class PublicThread(Thread):

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -634,67 +634,6 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             )
         )
 
-    async def start_thread_with_message(
-        self,
-        message: Optional[UserMessage],
-        name: Optional[str] = None,
-        auto_archive_duration: Optional[int] = None,
-        rate_limit_per_user: Optional[int] = None,
-        reason: Optional[str] = None,
-    ) -> Channel:
-        """|coro|
-        Creates a new thread from an existing message. Returns a Channel on
-        success.
-
-        When called on a ``GUILD_TEXT`` channel, creates a ``GUILD_PUBLIC_THREAD``.
-        When called on a ``GUILD_NEWS`` channel, creates a ``GUILD_NEWS_THREAD``.
-
-        The id of the created thread will be the same as the id of the message,
-        and as such a message can only have a single thread created from it.
-
-        Parameters
-        ----------
-        message: :class:`~pincer.objects.message.user_message.UserMessage`
-            The message to create the thread from.
-            |default| data:`None`
-        name: Optional[:class:`str`]
-            The name of the thread. 1-100 characters.
-            |default| data:`None`
-        auto_archive_duration: Optional[:class:`int`]
-            The duration in minutes to automatically archive the thread after
-            recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
-            |default| data:`None`
-        rate_limit_per_user: Optional[:class:`int`]
-            Amount of seconds a user has to wait before sending another message.
-            (0-21600)
-            |default| data:`None`
-        reason: Optional[:class:`str`]
-            The reason of the thread creation.
-            |default| data:`None`
-
-        The 3 day and 7 day archive durations require the server to be boosted.
-        The guild features will indicate if a server is able to use those settings.
-
-        Returns
-        -------
-        :class:`~pincer.objects.channel.Channel`
-            The created thread.
-        """
-        return Channel.from_dict(
-            construct_client_dict(
-                self._client,
-                await self._http.post(
-                    f"channels/{self.id}/messages/{message.id}/threads",
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
-                    data={
-                        "name": name,
-                        "auto_archive_duration": auto_archive_duration,
-                        "rate_limit_per_user": rate_limit_per_user,
-                    },
-                ),
-            )
-        )
-
     async def list_active_threads(self) -> ThreadsResponse:
         """|coro|
         Returns all active threads in the channel, including public and
@@ -1005,6 +944,67 @@ class Thread(Channel):
                         "auto_archive_duration": auto_archive_duration,
                         "type": type_,
                         "invitable": invitable,
+                        "rate_limit_per_user": rate_limit_per_user,
+                    },
+                ),
+            )
+        )
+
+    async def start_with_message(
+        self,
+        message: Optional[UserMessage],
+        name: Optional[str] = None,
+        auto_archive_duration: Optional[int] = None,
+        rate_limit_per_user: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> Channel:
+        """|coro|
+        Creates a new thread from an existing message. Returns a Channel on
+        success.
+
+        When called on a ``GUILD_TEXT`` channel, creates a ``GUILD_PUBLIC_THREAD``.
+        When called on a ``GUILD_NEWS`` channel, creates a ``GUILD_NEWS_THREAD``.
+
+        The id of the created thread will be the same as the id of the message,
+        and as such a message can only have a single thread created from it.
+
+        Parameters
+        ----------
+        message: :class:`~pincer.objects.message.user_message.UserMessage`
+            The message to create the thread from.
+            |default| data:`None`
+        name: Optional[:class:`str`]
+            The name of the thread. 1-100 characters.
+            |default| data:`None`
+        auto_archive_duration: Optional[:class:`int`]
+            The duration in minutes to automatically archive the thread after
+            recent activity, can be set to: ``60``, ``1440``, ``4320``, ``10080``.
+            |default| data:`None`
+        rate_limit_per_user: Optional[:class:`int`]
+            Amount of seconds a user has to wait before sending another message.
+            (0-21600)
+            |default| data:`None`
+        reason: Optional[:class:`str`]
+            The reason of the thread creation.
+            |default| data:`None`
+
+        The 3 day and 7 day archive durations require the server to be boosted.
+        The guild features will indicate if a server is able to use those settings.
+
+        Returns
+        -------
+        :class:`~pincer.objects.channel.Channel`
+            The created thread.
+        """
+        return Channel.from_dict(
+            construct_client_dict(
+                self._client,
+                await self._http.post(
+                    f"channels/{self.id}/messages/{message.id}/threads",
+                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    data={
+                        "name": name,
+                        "auto_archive_duration": auto_archive_duration,
                         "rate_limit_per_user": rate_limit_per_user,
                     },
                 ),

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -15,7 +15,7 @@ from ...utils.api_object import APIObject, GuildProperty
 from ...utils.conversion import construct_client_dict, remove_none
 from ...utils.convert_message import convert_message
 from ...utils.types import MISSING
-from ...objects import ThreadMember
+
 
 if TYPE_CHECKING:
     from typing import AsyncGenerator, Dict, List, Optional, Union
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from ..message.embed import Embed
     from ..user.user import User
     from ...client import Client
+    from ...objects import ThreadMember
     from ...utils.timestamp import Timestamp
     from ...utils.types import APINullable
     from ...utils.snowflake import Snowflake

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -243,7 +243,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         ...
 
     async def edit(self, reason: Optional[str] = None, **kwargs):
-        """Edit a channel with the given keyword arguments.
+        """|coro|
+        Edit a channel with the given keyword arguments.
 
         Parameters
         ----------
@@ -281,7 +282,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         type: int,
         reason: Optional[str] = None,
     ):
-        """
+        """|coro|
         Edit the channel permission overwrites for a user or role in a channel.
         Only usable for guild channels. Requires the ``MANAGE_ROLES`` permission.
         Only permissions your bot has in the guild or channel can be
@@ -309,7 +310,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def delete_permission(
         self, overwrite: Overwrite, reason: Optional[str] = None
     ):
-        """
+        """|coro|
         Delete a channel permission overwrite for a user or role in a channel.
         Only usable for guild channels. Requires the ``MANAGE_ROLES`` permission.
 
@@ -328,7 +329,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def follow_news_channel(
         self, webhook_channel_id: Snowflake
     ) -> NewsChannel:
-        """
+        """|coro|
         Follow a News Channel to send messages to a target channel.
         Requires the ``MANAGE_WEBHOOKS`` permission in the target channel.
         Returns a followed channel object.
@@ -354,7 +355,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def trigger_typing_indicator(self):
-        """
+        """|coro|
         Post a typing indicator for the specified channel.
         Generally bots should **not** implement this route. However, if a bot is
         responding to a command and expects the computation to take a few
@@ -364,7 +365,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         await self._http.post(f"channels/{self.id}/typing")
 
     async def get_pinned_messages(self) -> AsyncIterator[UserMessage]:
-        """
+        """|coro|
         Fetches all pinned messages in the channel. Returns an iterator of
         pinned messages.
 
@@ -382,7 +383,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def pin_message(
         self, message: UserMessage, reason: Optional[str] = None
     ):
-        """
+        """|coro|
         Pin a message in a channel. Requires the ``MANAGE_MESSAGES`` permission.
         The maximum number of pinned messages is ``50``.
         """
@@ -394,7 +395,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def unpin_message(
         self, message: UserMessage, reason: Optional[str] = None
     ):
-        """
+        """|coro|
         Unpin a message in a channel. Requires the ``MANAGE_MESSAGES`` permission.
         """
         await self._http.delete(
@@ -408,7 +409,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         access_token: Optional[str] = None,
         nick: Optional[str] = None,
     ):
-        """
+        """|coro|
         Adds a recipient to a Group DM using their access token.
 
         Parameters
@@ -427,7 +428,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         )
 
     async def group_dm_remove_recipient(self, user: User):
-        """
+        """|coro|
         Removes a recipient from a Group DM.
 
         Parameters
@@ -440,7 +441,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
     async def bulk_delete_messages(
         self, messages: List[Snowflake], reason: Optional[str] = None
     ):
-        """Delete multiple messages in a single request.
+        """|coro|
+        Delete multiple messages in a single request.
         This endpoint can only be used on guild channels and requires
         the ``MANAGE_MESSAGES`` permission.
 
@@ -997,7 +999,8 @@ class TextChannel(Channel):
         ...
 
     async def edit(self, **kwargs):
-        """Edit a text channel with the given keyword arguments.
+        """|coro|
+        Edit a text channel with the given keyword arguments.
 
         Parameters
         ----------
@@ -1047,7 +1050,8 @@ class VoiceChannel(Channel):
         ...
 
     async def edit(self, **kwargs):
-        """Edit a text channel with the given keyword arguments.
+        """|coro|
+        Edit a text channel with the given keyword arguments.
 
         Parameters
         ----------
@@ -1090,7 +1094,8 @@ class NewsChannel(Channel):
         ...
 
     async def edit(self, **kwargs):
-        """Edit a text channel with the given keyword arguments.
+        """|coro|
+        Edit a text channel with the given keyword arguments.
 
         Parameters
         ----------
@@ -1119,6 +1124,7 @@ class PrivateThread(Thread):
 
 @dataclass(repr=False)
 class ThreadsResponse(APIObject):
+    """A class representing a response from the API for a list of threads."""
     threads: AsyncIterator[Thread]
     members: AsyncIterator[ThreadMember]
     has_more: bool

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -842,20 +842,15 @@ class Channel(APIObject, GuildProperty):  # noqa E501
                 construct_client_dict(self._client, member)
             )
 
-    async def list_active_threads(self) -> Dict[str, Any]:
+    async def list_active_threads(self) -> ThreadsResponse:
         """|coro|
         Returns all active threads in the channel, including public and
         private threads. Threads are ordered by their id, in descending order.
 
         Returns
         -------
-        Dict[:class:`str`, :class:`Any`]
-            Dictionary containing the response body:
-                - threads: Generator of the active threads.
-                - members: Generator for each thread member object for each
-                returned thread the current user has joined.
-                - has_more: Whether there are potentially additional threads
-                that could be returned on a subsequent call.
+        :class:`~pincer.objects.channel.ThreadsResponse`
+            The response object.
         """
         return ThreadsResponse.from_dict(
             construct_client_dict(
@@ -866,7 +861,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
     async def list_public_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
-    ) -> Dict[str, Any]:
+    ) -> ThreadsResponse:
         """|coro|
         Returns archived threads in the channel that are public.
         When called on a ``GUILD_TEXT`` channel, returns threads of type
@@ -886,13 +881,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        Dict[:class:`str`, :class:`Any`]
-            Dictionary containing the response body:
-                - threads: Generator of the public archived threads.
-                - members: Generator for each thread member object for each
-                returned thread the current user has joined.
-                - has_more: Whether there are potentially additional threads
-                that could be returned on a subsequent call.
+        :class:`~pincer.objects.channel.ThreadsResponse`
+            The response object.
         """
         data = await self._http.get(
             f"channels/{self.id}/threads/archived/public",
@@ -904,7 +894,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
     async def list_private_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
-    ) -> Dict[str, Any]:
+    ) -> ThreadsResponse:
         """|coro|
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``. Threads are ordered by ``archive_timestamp``,
@@ -922,13 +912,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        Dict[:class:`str`, :class:`Any`]
-            Dictionary containing the response body:
-                - threads: Generator of the private archived threads.
-                - members: Generator for each thread member object for each
-                returned thread the current user has joined.
-                - has_more: Whether there are potentially additional threads
-                that could be returned on a subsequent call.
+        :class:`~pincer.objects.channel.ThreadsResponse`
+            The response object.
         """
         data = await self._http.get(
             f"channels/{self.id}/threads/archived/private",
@@ -940,7 +925,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
     async def list_joined_private_archived_threads(
         self, before: Optional[Timestamp] = None, limit: Optional[int] = None
-    ) -> Dict[str, Any]:
+    ) -> ThreadsResponse:
         """|coro|
         Returns archived threads in the channel that are of type
         ``GUILD_PRIVATE_THREAD``, and the user has joined. Threads are ordered
@@ -958,14 +943,8 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         Returns
         -------
-        Dict[:class:`str`, :class:`Any`]
-            Dictionary containing the response body:
-                - threads: Generator of the private archived threads
-                the user has joined.
-                - members: Generator for each thread member object for each
-                returned thread the current user has joined.
-                - has_more: Whether there are potentially additional threads
-                that could be returned on a subsequent call.
+        :class:`~pincer.objects.channel.ThreadsResponse`
+            The response object.
         """
         data = self._http.get(
             f"channels/{self.id}/users/@me/threads/archived/private",

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -9,7 +9,7 @@ from typing import AsyncGenerator, overload, TYPE_CHECKING
 
 from aiohttp import FormData
 
-from .channel import Channel
+from .channel import Channel, Thread
 from ..message.file import File
 from ...exceptions import UnavailableGuildError
 from ...utils.api_object import APIObject
@@ -506,7 +506,7 @@ class Guild(APIObject):
         )
         return GuildMember.from_dict(construct_client_dict(self._client, data))
 
-      
+
     @overload
     async def create_channel(
         self,
@@ -573,7 +573,7 @@ class Guild(APIObject):
         return Channel.from_dict(construct_client_dict(self._client, data))
 
     async def modify_channel_positions(
-        self, 
+        self,
         reason: Optional[str] = None,
         *channel: Dict[str, Optional[Union[int, bool, Snowflake]]]
     ):
@@ -598,11 +598,11 @@ class Guild(APIObject):
         )
 
     async def list_active_threads(self) -> Tuple[
-        Generator[Union[PublicThread, PrivateThread]], Generator[GuildMember]]:
+        Generator[Thread], Generator[GuildMember]]:
         """|coro|
         Returns all active threads in the guild,
         including public and private threads.
-        
+
         Returns
         -------
         Generator[Union[:class:`~pincer.objects.guild.channel.PublicThread`, :class:`~pincer.objects.guild.channel.PrivateThread`]], Generator[:class:`~pincer.objects.guild.member.GuildMember`]]
@@ -635,7 +635,7 @@ class Guild(APIObject):
             max number of members to return (1-1000) |default| :data:`1`
         after : int
             the highest user id in the previous page |default| :data:`0`
-        
+
         Yields
         ------
         :class:`~pincer.objects.guild.member.GuildMember`
@@ -645,15 +645,15 @@ class Guild(APIObject):
         members = await self._http.get(
             f"guilds/{self.id}/members?{limit=}&{after=}"
         )
-        
+
         for member in members:
             yield GuildMember.from_dict(
                 construct_client_dict(self._client, member)
             )
-        
+
 
     async def search_guild_members(
-        self, 
+        self,
         query: str,
         limit: Optional[int] = None
     ) -> AsyncIterator[GuildMember]:
@@ -667,7 +667,7 @@ class Guild(APIObject):
             Query string to match username(s) and nickname(s) against.
         limit : Optional[int]
             max number of members to return (1-1000) |default| :data:`1`
-            
+
         Yields
         -------
         :class:`~pincer.objects.guild.member.GuildMember`
@@ -702,7 +702,7 @@ class Guild(APIObject):
         user_id : str
             id of the user to be added
         access_token : str
-            an oauth2 access token granted with the guilds.join to 
+            an oauth2 access token granted with the guilds.join to
             the bot's application for the user you want to add to the guild
         nick : Optional[str]
         	value to set users nickname to
@@ -724,12 +724,12 @@ class Guild(APIObject):
 
     async def add_guild_member(
         self,
-        user_id, 
-        reason=None, 
+        user_id,
+        reason=None,
         **kwargs
     ):
         data = await self._http.put(
-            f"guilds/{self.id}/members/{user_id}", 
+            f"guilds/{self.id}/members/{user_id}",
             data=kwargs,
             headers=remove_none({"X-Audit-Log-Reason": reason})
         )
@@ -739,8 +739,8 @@ class Guild(APIObject):
         ) if data else None
 
     async def modify_current_member(
-        self, 
-        nick: str, 
+        self,
+        nick: str,
         reason: Optional[str] = None
     ) -> GuildMember:
         """|coro|
@@ -758,8 +758,8 @@ class Guild(APIObject):
             current guild member
         """
         data = self._http.patch(
-            f"guilds/{self.id}/members/@me", 
-            {"nick": nick}, 
+            f"guilds/{self.id}/members/@me",
+            {"nick": nick},
             headers=remove_none({"X-Audit-Log-Reason":reason})
         )
         return GuildMember.from_dict(construct_client_dict(self._client, data))
@@ -788,7 +788,7 @@ class Guild(APIObject):
         )
 
     async def remove_guild_member_role(
-        self, 
+        self,
         user_id: int,
         role_id: int,
         reason: Optional[str] = None
@@ -1660,7 +1660,7 @@ class Guild(APIObject):
             The newly created emoji object.
         """
         roles = [] if roles is None else roles
-        
+
         data = await self._http.post(
             f"guilds/{self.id}/emojis",
             data={"name": name, "image": image.uri, "roles": roles},
@@ -1846,7 +1846,7 @@ class Guild(APIObject):
     async def list_stickers(self) -> AsyncIterator[Sticker]:
         """|coro|
         Yields sticker objects for the current guild.
-        Includes ``user`` fields if the bot has the 
+        Includes ``user`` fields if the bot has the
         ``MANAGE_EMOJIS_AND_STICKERS`` permission.
 
         Yields
@@ -1861,7 +1861,7 @@ class Guild(APIObject):
     async def get_sticker(self, _id: Snowflake) -> Sticker:
         """|coro|
         Returns a sticker object for the current guild and sticker IDs.
-        Includes the ``user`` field if the bot has the 
+        Includes the ``user`` field if the bot has the
         ``MANAGE_EMOJIS_AND_STICKERS`` permission.
 
         Parameters


### PR DESCRIPTION
### Changes

- `adds`:
  - New `Thread` class, which `PrivateThread` and `PublicThread` will inherit from.
  - 8 methods to `Thread`:
    - `start_with_message`
    - `start`
    - `join`
    - `add_member`
    - `leave`
    - `remove_member`
    - `get_member`
    - `list_members`
  - 4 methods to `Channel`:
    - `list_active_threads`
    - `list_public_archived_threads`
    - `list_private_archived_threads`
    - `list_joined_private_archived_threads`

 ### Check off the following

-   [X] I have tested my changes with the current requirements
-   [X] My Code follows the pep8 code style.
