### PR TITLE
:sparkles: Add `$referrer` and `$referring_domain`

### DIFF
--- a/pincer/core/gateway.py
+++ b/pincer/core/gateway.py
@@ -353,7 +353,9 @@ class Gateway:
                     "properties": {
                         "$os": system(),
                         "$browser": __package__,
-                        "$device": __package__
+                        "$device": __package__,
+                        "$referrer": "",
+                        "$referring_domain": ""
                     },
                     "compress": GatewayConfig.compressed(),
                     "shard": self.shard_key


### PR DESCRIPTION
### Changes

-   `adds`: `$referrer` & `$referring_domain` when identifying

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
