### PR TITLE
♻️ Added query params parameter to HTTP get requests

### DIFF
--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -19,6 +19,7 @@ from ..exceptions import (
     ForbiddenError, MethodNotAllowedError, RateLimitError, ServerError,
     HTTPError
 )
+from ..utils.conversion import remove_none
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional, Union
@@ -114,6 +115,7 @@ class HTTPClient:
             content_type: str = "application/json",
             data: Optional[Union[Dict, str, Payload]] = None,
             headers: Optional[Dict[str, Any]] = None,
+            params: Optional[Dict] = None,
             __ttl: int = None
     ) -> Optional[Dict]:
         """
@@ -132,6 +134,12 @@ class HTTPClient:
 
         data:
             The data which will be added to the request.
+
+        headers:
+            The request headers.
+
+        params:
+            The query parameters to add to the request.
 
         __ttl:
             Private param used for recursively setting the retry amount.
@@ -167,7 +175,8 @@ class HTTPClient:
                 headers={
                     "Content-Type": content_type,
                     **(headers or {})
-                }
+                },
+                params=params
         ) as res:
             return await self.__handle_response(
                 res, method, endpoint, content_type, data, ttl
@@ -301,7 +310,11 @@ class HTTPClient:
             headers=headers
         )
 
-    async def get(self, route: str) -> Optional[Dict]:
+    async def get(
+        self,
+        route: str,
+        params: Optional[dict] = None
+    ) -> Optional[Dict]:
         """|coro|
 
         Sends a get request to a Discord REST endpoint.
@@ -310,13 +323,20 @@ class HTTPClient:
         ----------
         route : :class:`str`
             The Discord REST endpoint to send a get request to.
+        params: Optional[:class:`dict`]
+            The query parameters to add to the request.
+            |default| :data:`None`
 
         Returns
         -------
         Optional[:class:`dict`]
             The response from discord.
         """
-        return await self.__send(self.__session.get, route)
+        return await self.__send(
+            self.__session.get,
+            route,
+            params=remove_none(params)
+        )
 
     async def head(self, route: str) -> Optional[Dict]:
         """|coro|

--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -176,7 +176,7 @@ class HTTPClient:
                     "Content-Type": content_type,
                     **(headers or {})
                 },
-                params=params
+                params=remove_none(params)
         ) as res:
             return await self.__handle_response(
                 res, method, endpoint, content_type, data, ttl
@@ -335,7 +335,7 @@ class HTTPClient:
         return await self.__send(
             self.__session.get,
             route,
-            params=remove_none(params)
+            params=params
         )
 
     async def head(self, route: str) -> Optional[Dict]:

--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -121,29 +121,34 @@ class HTTPClient:
         """
         Send an api request to the Discord REST API.
 
-        method:
+        Parameters
+        ----------
+
+        method: :class:`aiohttp.ClientSession.request`
             The method for the request. (e.g. GET or POST)
 
-        endpoint:
+        endpoint: :class:`str`
             The endpoint to which the request will be sent.
 
-        Keyword Arguments:
-
-        content_type:
+        content_type: :class:`str`
             The request's content type.
 
-        data:
+        data: Optional[Union[:class:`Dict`, :class:`str`, :class:`aiohttp.payload.Payload`]]
             The data which will be added to the request.
+            |default| :data:`None`
 
-        headers:
+        headers: Optional[:class:`Dict`]
             The request headers.
+            |default| :data:`None`
 
-        params:
+        params: Optional[:class:`Dict`]
             The query parameters to add to the request.
+            |default| :data:`None`
 
-        __ttl:
+        __ttl: Optional[:class:`int`]
             Private param used for recursively setting the retry amount.
             (Eg set to 1 for 1 max retry)
+            |default| :data:`None`
         """
         ttl = __ttl or self.max_ttl
 
@@ -197,22 +202,25 @@ class HTTPClient:
         Side effects:
             If a 5xx error code is returned it will retry the request.
 
-        res:
+        Parameters
+        ----------
+
+        res: :class:`aiohttp.ClientResponse`
             The response from the discord API.
 
-        method:
+        method: :class:`aiohttp.ClientSession.request`
             The method which was used to call the endpoint.
 
-        endpoint:
+        endpoint: :class:`str`
             The endpoint to which the request was sent.
 
-        content_type:
+        content_type: :class:`str`
             The request's content type.
 
-        data:
+        data: Optional[:class:`str`]
             The data which was added to the request.
 
-        __ttl:
+        __ttl: :class:`int`
             Private param used for recursively setting the retry amount.
             (Eg set to 1 for 1 max retry)
         """
@@ -301,7 +309,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             The response from discord.
         """
         return await self.__send(
@@ -313,7 +321,7 @@ class HTTPClient:
     async def get(
         self,
         route: str,
-        params: Optional[dict] = None
+        params: Optional[Dict] = None
     ) -> Optional[Dict]:
         """|coro|
 
@@ -323,13 +331,13 @@ class HTTPClient:
         ----------
         route : :class:`str`
             The Discord REST endpoint to send a get request to.
-        params: Optional[:class:`dict`]
+        params: Optional[:class:`Dict`]
             The query parameters to add to the request.
             |default| :data:`None`
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             The response from discord.
         """
         return await self.__send(
@@ -350,7 +358,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             The response from discord.
         """
         return await self.__send(self.__session.head, route)
@@ -367,7 +375,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             The response from discord.
         """
         return await self.__send(self.__session.options, route)
@@ -387,7 +395,7 @@ class HTTPClient:
         ----------
         route : :class:`str`
             The Discord REST endpoint to send a patch request to.
-        data : :class:`dict`
+        data : :class:`Dict`
             The update data for the patch request.
         content_type: :class:`str`
             Body content type.
@@ -397,7 +405,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             JSON response from the discord API.
         """
         return await self.__send(
@@ -432,7 +440,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             JSON response from the discord API.
         """
         return await self.__send(
@@ -467,7 +475,7 @@ class HTTPClient:
 
         Returns
         -------
-        Optional[:class:`dict`]
+        Optional[:class:`Dict`]
             JSON response from the discord API.
         """
         return await self.__send(

--- a/pincer/core/http.py
+++ b/pincer/core/http.py
@@ -179,7 +179,7 @@ class HTTPClient:
                 data=data,
                 headers={
                     "Content-Type": content_type,
-                    **(headers or {})
+                    **(remove_none(headers) or {})
                 },
                 params=remove_none(params)
         ) as res:

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -681,9 +681,12 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             construct_client_dict(
                 self._client,
                 await self._http.get(
-                    f"channels/{self.id}/threads/archived/public?"
-                    + urlencode(remove_none({"before": before, "limit": limit}))
-                ),
+                    f"channels/{self.id}/threads/archived/public",
+                    params={
+                        "before": before,
+                        "limit": limit
+                    }
+                )
             )
         )
 
@@ -714,9 +717,12 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             construct_client_dict(
                 self._client,
                 await self._http.get(
-                    f"channels/{self.id}/threads/archived/private?"
-                    + urlencode(remove_none({"before": before, "limit": limit}))
-                ),
+                    f"channels/{self.id}/threads/archived/private",
+                    params={
+                        "before": before,
+                        "limit": limit
+                    }
+                )
             )
         )
 
@@ -748,8 +754,11 @@ class Channel(APIObject, GuildProperty):  # noqa E501
             construct_client_dict(
                 self._client,
                 self._http.get(
-                    f"channels/{self.id}/users/@me/threads/archived/private?"
-                    + urlencode(remove_none({"before": before, "limit": limit}))
+                    f"channels/{self.id}/users/@me/threads/archived/private",
+                    params={
+                        "before": before,
+                        "limit": limit
+                    }
                 ),
             )
         )

--- a/pincer/objects/guild/channel.py
+++ b/pincer/objects/guild/channel.py
@@ -303,7 +303,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.put(
             f"channels/{self.id}/permissions/{overwrite.id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
             data={"allow": allow, "deny": deny, "type": type},
         )
 
@@ -323,7 +323,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.delete(
             f"channels/{self.id}/permissions/{overwrite.id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def follow_news_channel(
@@ -389,7 +389,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.put(
             f"channels/{self.id}/pins/{message.id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def unpin_message(
@@ -400,7 +400,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.delete(
             f"channels/{self.id}/pins/{message.id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def group_dm_add_recipient(
@@ -459,7 +459,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
         """
         await self._http.post(
             f"channels/{self.id}/messages/bulk_delete",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
             data={"messages": messages},
         )
 
@@ -484,7 +484,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
 
         await self._http.delete(
             f"channels/{channel_id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def __post_send_handler(self, message: UserMessage):
@@ -621,7 +621,7 @@ class Channel(APIObject, GuildProperty):  # noqa E501
                 self._client,
                 await self._http.post(
                     f"channels/{self.id}/invites",
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    headers={"X-Audit-Log-Reason": reason},
                     data={
                         "max_age": max_age,
                         "max_uses": max_uses,
@@ -955,7 +955,7 @@ class Thread(Channel):
                 self._client,
                 await self._http.post(
                     f"channels/{self.id}/threads",
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    headers={"X-Audit-Log-Reason": reason},
                     data={
                         "name": name,
                         "auto_archive_duration": auto_archive_duration,
@@ -1018,7 +1018,7 @@ class Thread(Channel):
                 self._client,
                 await self._http.post(
                     f"channels/{self.id}/messages/{message.id}/threads",
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    headers={"X-Audit-Log-Reason": reason},
                     data={
                         "name": name,
                         "auto_archive_duration": auto_archive_duration,

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -502,7 +502,7 @@ class Guild(APIObject):
         data = await self._http.patch(
             f"guilds/{self.id}/members/{_id}",
             data=kwargs,
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
         return GuildMember.from_dict(construct_client_dict(self._client, data))
 
@@ -568,7 +568,7 @@ class Guild(APIObject):
         data = await self._http.post(
             f"guilds/{self.id}/channels",
             data=kwargs,
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
         return Channel.from_dict(construct_client_dict(self._client, data))
 
@@ -594,7 +594,7 @@ class Guild(APIObject):
         await self._http.patch(
             f"guilds/{self.id}/channels",
             data=channel,
-            headers=remove_none({"X-Audit-Log-Reason":reason})
+            headers={"X-Audit-Log-Reason":reason}
         )
 
     async def list_active_threads(self) -> Tuple[
@@ -738,7 +738,7 @@ class Guild(APIObject):
         data = await self._http.put(
             f"guilds/{self.id}/members/{user_id}",
             data=kwargs,
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
 
         return GuildMember.from_dict(
@@ -767,7 +767,7 @@ class Guild(APIObject):
         data = self._http.patch(
             f"guilds/{self.id}/members/@me",
             {"nick": nick},
-            headers=remove_none({"X-Audit-Log-Reason":reason})
+            headers={"X-Audit-Log-Reason":reason}
         )
         return GuildMember.from_dict(construct_client_dict(self._client, data))
 
@@ -791,7 +791,7 @@ class Guild(APIObject):
         """
         data = await self._http.put(
             f"guilds/{self.id}/{user_id}/roles/{role_id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
 
     async def remove_guild_member_role(
@@ -814,7 +814,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/{user_id}/roles/{role_id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
 
     async def remove_guild_member(
@@ -834,7 +834,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/members/{user_id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason})
+            headers={"X-Audit-Log-Reason": reason}
         )
 
     async def ban(
@@ -955,7 +955,7 @@ class Guild(APIObject):
                 await self._http.post(
                     f"guilds/{self.id}/roles",
                     data=kwargs,
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    headers={"X-Audit-Log-Reason": reason},
                 ),
             )
         )
@@ -986,7 +986,7 @@ class Guild(APIObject):
         data = await self._http.patch(
             f"guilds/{self.id}/roles",
             data={"id": id, "position": position},
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
         for role_data in data:
             yield Role.from_dict(construct_client_dict(self._client, role_data))
@@ -1050,7 +1050,7 @@ class Guild(APIObject):
                 await self._http.patch(
                     f"guilds/{self.id}/roles/{id}",
                     data=kwargs,
-                    headers=remove_none({"X-Audit-Log-Reason": reason}),
+                    headers={"X-Audit-Log-Reason": reason},
                 ),
             )
         )
@@ -1069,7 +1069,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/roles/{id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def get_bans(self) -> AsyncGenerator[Ban, None]:
@@ -1119,7 +1119,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/bans/{id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     @overload
@@ -1290,7 +1290,7 @@ class Guild(APIObject):
                 "compute_prune_days": compute_prune_days,
                 "include_roles": include_roles,
             },
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )["pruned"]
 
     async def get_voice_regions(self) -> AsyncGenerator[VoiceRegion, None]:
@@ -1356,7 +1356,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/integrations/{integration.id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def get_widget_settings(self) -> GuildWidget:
@@ -1397,7 +1397,7 @@ class Guild(APIObject):
         data = await self._http.patch(
             f"guilds/{self.id}/widget",
             data=kwargs,
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
         return GuildWidget.from_dict(construct_client_dict(self._client, data))
 
@@ -1509,7 +1509,7 @@ class Guild(APIObject):
                 "welcome_channels": welcome_channels,
                 "description": description,
             },
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
         return WelcomeScreen.from_dict(
             construct_client_dict(self._client, data)
@@ -1672,7 +1672,7 @@ class Guild(APIObject):
         data = await self._http.post(
             f"guilds/{self.id}/emojis",
             data={"name": name, "image": image.uri, "roles": roles},
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
         return Emoji.from_dict(construct_client_dict(self._client, data))
 
@@ -1707,7 +1707,7 @@ class Guild(APIObject):
         data = await self._http.patch(
             f"guilds/{self.id}/emojis/{id}",
             data={"name": name, "roles": roles},
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
         return Emoji.from_dict(construct_client_dict(self._client, data))
 
@@ -1727,7 +1727,7 @@ class Guild(APIObject):
         """
         await self._http.delete(
             f"guilds/{self.id}/emojis/{id}",
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
     async def get_templates(self) -> AsyncIterator[GuildTemplate]:
@@ -1931,7 +1931,7 @@ class Guild(APIObject):
         sticker = await self._http.post(
             f"guilds/{self.id}/stickers",
             data=payload,
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
             content_type=payload.content_type
         )
 

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -643,7 +643,11 @@ class Guild(APIObject):
         """
 
         members = await self._http.get(
-            f"guilds/{self.id}/members?{limit=}&{after=}"
+            f"guilds/{self.id}/members",
+            params={
+                "limit": limit,
+                "after": after
+            }
         )
 
         for member in members:
@@ -675,8 +679,11 @@ class Guild(APIObject):
         """
 
         data = await self._http.get(
-            f"guilds/{id}/members/search?{query=!s}"
-            + (f"&{limit=}" if limit else "")
+            f"guilds/{self.id}/members/search",
+            params={
+                "query": query,
+                "limit": limit
+            }
         )
 
         for member in data:
@@ -1243,7 +1250,8 @@ class Guild(APIObject):
             The number of members that would be removed.
         """
         return await self._http.get(
-            f"guilds/{self.id}/prune?{days=}&{include_roles=!s}"
+            f"guilds/{self.id}/prune",
+            params={"days": days, "include_roles": include_roles},
         )["pruned"]
 
     async def prune(

--- a/pincer/objects/guild/webhook.py
+++ b/pincer/objects/guild/webhook.py
@@ -323,8 +323,8 @@ class Webhook(APIObject):
             construct_client_dict(
                 self._client,
                 await self._http.get(
-                    f"webhooks/{self.id}/{self.token}/messages/{message_id}"
-                    + (f"?{thread_id=}" if thread_id else "")
+                    f"webhooks/{self.id}/{self.token}/messages/{message_id}",
+                    params={"thread_id": thread_id}
                 )
             )
         )

--- a/pincer/objects/message/sticker.py
+++ b/pincer/objects/message/sticker.py
@@ -147,7 +147,7 @@ class Sticker(APIObject):
             data=remove_none(
                 {"name": name, "description": description, "tags": tags}
             ),
-            headers=remove_none({"X-Audit-Log-Reason": reason}),
+            headers={"X-Audit-Log-Reason": reason},
         )
 
         return Sticker.from_dict(sticker)

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -478,8 +478,8 @@ class UserMessage(APIObject, GuildProperty, ChannelProperty):
         """
 
         for user in await self._http.get(
-            f"/channels/{self.channel_id}/messages/{self.id}/reactions/{emoji}"
-            f"?after={after}&limit={limit}"
+            f"/channels/{self.channel_id}/messages/{self.id}/reactions/{emoji}",
+            params={"after": after, "limit": limit}
         ):
             yield User.from_dict(user)
 


### PR DESCRIPTION
### Changes

-   `adds`: The ability to specify a `params` keyword argument in the HTTP get request, which will add the supplied dictionary to the query url, instead of doing it manually on each endpoint that requires this.
-   `fixed`: `Guild.search_guild_members` not working due to an incorrect variable in the request url.
-   `improvements`: All methods using query parameters were refactored for using this.

 ### Check off the following

-   [X] I have tested my changes with the current requirements
-   [X] My Code follows the pep8 code style.
