### PR TITLE
:bug: Fix MessageUpdate event causing crash

### DIFF
--- a/pincer/commands/commands.py
+++ b/pincer/commands/commands.py
@@ -486,7 +486,7 @@ def message_command(
 
 
 def register_command(
-    func: function=None,  # Missing typehint?
+    func=None,  # Missing typehint?
     *,
     app_command_type: Optional[AppCommandType] = None,
     name: Optional[str] = None,

--- a/pincer/commands/commands.py
+++ b/pincer/commands/commands.py
@@ -486,7 +486,7 @@ def message_command(
 
 
 def register_command(
-    func=None,  # Missing typehint?
+    func: function=None,  # Missing typehint?
     *,
     app_command_type: Optional[AppCommandType] = None,
     name: Optional[str] = None,

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -325,11 +325,11 @@ class UserMessage(APIObject, GuildProperty, ChannelProperty):
         Sent if the message contains stickers
     """  # noqa: E501
 
-    # Always gaurenteed
+    # Always guaranteed
     id: Snowflake
     channel_id: Snowflake
 
-    # Only gaurenteed in Message Create event
+    # Only guaranteed in Message Create event
     author: APINullable[User] = MISSING
     content: APINullable[str] = MISSING
     timestamp: APINullable[Timestamp] = MISSING
@@ -342,7 +342,7 @@ class UserMessage(APIObject, GuildProperty, ChannelProperty):
     pinned: APINullable[bool] = MISSING
     type: APINullable[MessageType] = MISSING
 
-    # Never gaurenteed
+    # Never guaranteed
     edited_timestamp: APINullable[Timestamp] = MISSING
     mention_channels: APINullable[List[ChannelMention]] = MISSING
     guild_id: APINullable[Snowflake] = MISSING

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -323,9 +323,7 @@ class UserMessage(APIObject, GuildProperty, ChannelProperty):
         action rows, or other interactive components
     sticker_items: APINullable[List[:class:`~pincer.objects.message.sticker.StickerItem`]]
         Sent if the message contains stickers
-    """
-
-    # noqa: E501
+    """  # noqa: E501
 
     # Always gaurenteed
     id: Snowflake

--- a/pincer/objects/message/user_message.py
+++ b/pincer/objects/message/user_message.py
@@ -327,20 +327,24 @@ class UserMessage(APIObject, GuildProperty, ChannelProperty):
 
     # noqa: E501
 
+    # Always gaurenteed
     id: Snowflake
     channel_id: Snowflake
-    author: User
-    content: str
-    timestamp: Timestamp
-    tts: bool
-    mention_everyone: bool
-    mentions: List[GuildMember]
-    mention_roles: List[Role]
-    attachments: List[Attachment]
-    embeds: List[Embed]
-    pinned: bool
-    type: MessageType
 
+    # Only gaurenteed in Message Create event
+    author: APINullable[User] = MISSING
+    content: APINullable[str] = MISSING
+    timestamp: APINullable[Timestamp] = MISSING
+    tts: APINullable[bool] = MISSING
+    mention_everyone: APINullable[bool] = MISSING
+    mentions: APINullable[List[GuildMember]] = MISSING
+    mention_roles: APINullable[List[Role]] = MISSING
+    attachments: APINullable[List[Attachment]] = MISSING
+    embeds: APINullable[List[Embed]] = MISSING
+    pinned: APINullable[bool] = MISSING
+    type: APINullable[MessageType] = MISSING
+
+    # Never gaurenteed
     edited_timestamp: APINullable[Timestamp] = MISSING
     mention_channels: APINullable[List[ChannelMention]] = MISSING
     guild_id: APINullable[Snowflake] = MISSING


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes
The problem was that the event only sends parts of a UserMessage object. We either can do what I did or create a new object thats a clone of UserMessage but everything is optional.

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
