### PR TITLE
:bug: gateway no longer starts multiple instances

### DIFF
--- a/pincer/core/dispatch.py
+++ b/pincer/core/dispatch.py
@@ -30,12 +30,12 @@ class GatewayDispatch:
     def __init__(
             self,
             op: int,
-            data: Optional[Union[int, Dict[str, Any]]] = None,
+            data: Optional[Union[int, bool, Dict[str, Any]]] = None,
             seq: Optional[int] = None,
             name: Optional[str] = None
     ):
         self.op: int = op
-        self.data: Optional[Union[int, Dict[str, Any]]] = data
+        self.data: Optional[Union[int, bool, Dict[str, Any]]] = data
         self.seq: Optional[int] = seq
         self.event_name: Optional[str] = name
 

--- a/pincer/core/gateway.py
+++ b/pincer/core/gateway.py
@@ -312,7 +312,6 @@ class Gateway:
         )
 
         self.__should_resume = True
-        self.stop_heartbeat()
         await self.__socket.close()
 
     async def handle_invalid_session(self, payload: GatewayDispatch):
@@ -368,8 +367,6 @@ class Gateway:
         ))
         self.__heartbeat_interval = payload.data["heartbeat_interval"]
 
-        # This process should already be forked to the background so there is no need to
-        # `ensure_future()` here.
         self.start_heartbeat()
 
     async def handle_heartbeat(self, payload: GatewayDispatch):

--- a/pincer/core/gateway.py
+++ b/pincer/core/gateway.py
@@ -328,6 +328,8 @@ class Gateway:
         )
 
         self.__should_resume = payload.data
+        self.stop_heartbeat()
+        await self.__socket.close()
 
     async def identify_and_handle_hello(self, payload: GatewayDispatch):
         """|coro|

--- a/pincer/core/gateway.py
+++ b/pincer/core/gateway.py
@@ -321,10 +321,11 @@ class Gateway:
         when we tried to reconnect.
         """
 
-        if payload.data:
-            _log.debug("%s Invalid session, attempting to reconnect...", self.shard_key)
-        else:
-            _log.debug("%s Invalid session, attempting to relog...", self.shard_key)
+        _log.debug(
+            "%s Invalid session, attempting to %s...",
+            self.shard_key,
+            "reconnect" if payload.data else "relog"
+        )
 
         self.__should_resume = payload.data
 


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

-   `fixed`: Disconnect bug where it started 5k times :skull: should be patched

Tested for ~5 hours at the time of making this PR and I forced a reconnect by unplugging my wifi xD to make sure it went smoothly.
Opcode 9 hasn't been tested since I haven't gotten the payload. Should work as it functions the same as the heartbeat disconnect.

Notes
close code 1001 was changed to 4000 because 1001 would turn the bot offline. 4000 is also a websocket close close officially available to application, discord uses it for unknown disconnects, and it isn't 1000.
`__should_reconnect` was renamed to `__should_resume` because that was what it actually did.
Line 325 was changed because I missed that in the docs when I read it the first time.
 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
