### PR TITLE
:bug: Make sort-alls work on all branches

### DIFF
--- a/.github/workflows/sort_alls.yaml
+++ b/.github/workflows/sort_alls.yaml
@@ -29,4 +29,4 @@ jobs:
           git pull
           git add .
           git diff-index --quiet HEAD || git commit -m ":art: Automatic `__all__` sorting"
-          git push origin main
+          git push

--- a/.github/workflows/sort_alls.yaml
+++ b/.github/workflows/sort_alls.yaml
@@ -1,9 +1,6 @@
 name: Sort Alls
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   build:

--- a/pincer/__init__.py
+++ b/pincer/__init__.py
@@ -59,8 +59,8 @@ version_info = VersionInfo(0, 15, 1)
 __version__ = repr(version_info)
 
 __all__ = (
-    "BadRequestError", "Bot", "ChatCommandHandler", "Client", "CommandAlreadyRegistered",
-    "CogAlreadyExists", "CogError", "CogNotFound",
+    "BadRequestError", "Bot", "ChatCommandHandler", "Client",
+    "CogAlreadyExists", "CogError", "CogNotFound", "CommandAlreadyRegistered",
     "CommandCooldownError", "CommandDescriptionTooLong", "CommandError",
     "CommandIsNotCoroutine", "CommandReturnIsEmpty", "DisallowedIntentsError",
     "DispatchError", "EmbedFieldError", "EmbedOverflow", "ForbiddenError",

--- a/pincer/__init__.py
+++ b/pincer/__init__.py
@@ -59,8 +59,8 @@ version_info = VersionInfo(0, 15, 1)
 __version__ = repr(version_info)
 
 __all__ = (
-    "BadRequestError", "Bot", "ChatCommandHandler", "Client",
-    "CogAlreadyExists", "CogError", "CogNotFound", "CommandAlreadyRegistered",
+    "BadRequestError", "Bot", "ChatCommandHandler", "Client", "CommandAlreadyRegistered",
+    "CogAlreadyExists", "CogError", "CogNotFound",
     "CommandCooldownError", "CommandDescriptionTooLong", "CommandError",
     "CommandIsNotCoroutine", "CommandReturnIsEmpty", "DisallowedIntentsError",
     "DispatchError", "EmbedFieldError", "EmbedOverflow", "ForbiddenError",


### PR DESCRIPTION
<!-- Please complete the missing ... parts. -->

### Changes

Its kinda annoying how automatic sorting shows up after squashing/merging a PR so this should fix it

edit: I did not intend to make a branch on the main repo :skull: but im too lazy to fix it.

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
