### PR TITLE
✨ Adding approx member count

### DIFF
--- a/pincer/client.py
+++ b/pincer/client.py
@@ -865,13 +865,17 @@ class Client:
             event_name, check, iteration_timeout, loop_timeout
         )
 
-    async def get_guild(self, guild_id: int) -> Guild:
+    async def get_guild(self, guild_id: int, with_count: bool = False) -> Guild:
         """|coro|
 
         Fetch a guild object by the guild identifier.
 
         Parameters
         ----------
+        with_count: :class:bool
+            Whether to include the member count in the guild object.
+            Default to `False`
+
         guild_id : :class:`int`
             The id of the guild which should be fetched from the Discord
             gateway.
@@ -881,7 +885,7 @@ class Client:
         :class:`~pincer.objects.guild.guild.Guild`
             The guild object.
         """
-        return await Guild.from_id(self, guild_id)
+        return await Guild.from_id(self, guild_id, with_count)
 
     async def get_user(self, _id: int) -> User:
         """|coro|

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -434,7 +434,7 @@ class Guild(APIObject):
         data = await client.http.get(
             f"/guilds/{_id}",
             # Yarl don't support boolean params
-            params={"with_counts": ("true" * with_counts) or None},
+            params={"with_counts": "true" if with_counts else None},
         )
         channel_data = await client.http.get(f"/guilds/{_id}/channels")
 

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -413,7 +413,12 @@ class Guild(APIObject):
     welcome_screen: APINullable[WelcomeScreen] = MISSING
 
     @classmethod
-    async def from_id(cls, client: Client, _id: Union[int, Snowflake], with_counts: bool = False) -> Guild:
+    async def from_id(
+        cls,
+        client: Client,
+        _id: Union[int, Snowflake],
+        with_counts: bool = False,
+    ) -> Guild:
         """
         Parameters
         ----------

--- a/pincer/objects/guild/guild.py
+++ b/pincer/objects/guild/guild.py
@@ -413,7 +413,7 @@ class Guild(APIObject):
     welcome_screen: APINullable[WelcomeScreen] = MISSING
 
     @classmethod
-    async def from_id(cls, client: Client, _id: Union[int, Snowflake]) -> Guild:
+    async def from_id(cls, client: Client, _id: Union[int, Snowflake], with_counts: bool = False) -> Guild:
         """
         Parameters
         ----------
@@ -426,7 +426,11 @@ class Guild(APIObject):
         :class:`~pincer.objects.guild.guild.Guild`
             The new guild object.
         """
-        data = await client.http.get(f"/guilds/{_id}")
+        data = await client.http.get(
+            f"/guilds/{_id}",
+            # Yarl don't support boolean params
+            params={"with_counts": ("true" * with_counts) or None},
+        )
         channel_data = await client.http.get(f"/guilds/{_id}/channels")
 
         data["channels"]: List[Channel] = [


### PR DESCRIPTION
> before
![image](https://user-images.githubusercontent.com/53050011/148707843-f64d4722-44da-4bb8-a8d4-0f6b6e2230bc.png)

```py
g = await self.get_guild(..., with_count=True)
member_count = g.approximate_member_count

await c.send(
    Embed(description=f"There is {member_count} members in this server!")
)
```
![image](https://user-images.githubusercontent.com/53050011/148707924-dbd3f854-c290-40be-8b28-74c226102d45.png)