### PR TITLE
🐛 Fixed command parameters types

### DIFF
--- a/pincer/objects/app/interactions.py
+++ b/pincer/objects/app/interactions.py
@@ -154,12 +154,15 @@ class Interaction(APIObject, ChannelProperty, GuildProperty):
             elif option.type == AppCommandOptionType.NUMBER:
                 option.value = float(option.value)
 
-            elif option.type == AppCommandOptionType.USER:
+            elif option.type is AppCommandOptionType.USER:
                 user = self.return_type(option, self.data.resolved.members)
-                user.set_user_data(
-                    self.return_type(option, self.data.resolved.users)
-                )
-                option.value = user
+                if user:
+                    user.set_user_data(
+                        self.return_type(option, self.data.resolved.users)
+                    )
+                    option.value = user
+                else:
+                    option.value = self.return_type(option, self.data.resolved.users)
 
             elif option.type == AppCommandOptionType.CHANNEL:
                 option.value = self.return_type(

--- a/pincer/objects/app/interactions.py
+++ b/pincer/objects/app/interactions.py
@@ -145,33 +145,33 @@ class Interaction(APIObject, ChannelProperty, GuildProperty):
             return
 
         for option in self.data.options:
-            if option.type is AppCommandOptionType.STRING:
+            if option.type == AppCommandOptionType.STRING:
                 option.value = str(option.value)
-            elif option.type is AppCommandOptionType.INTEGER:
+            elif option.type == AppCommandOptionType.INTEGER:
                 option.value = int(option.value)
-            elif option.type is AppCommandOptionType.BOOLEAN:
-                option.value = bool(option.value)
-            elif option.type is AppCommandOptionType.NUMBER:
+            elif option.type == AppCommandOptionType.BOOLEAN:
+                option.value = option.value == "True"
+            elif option.type == AppCommandOptionType.NUMBER:
                 option.value = float(option.value)
 
-            elif option.type is AppCommandOptionType.USER:
+            elif option.type == AppCommandOptionType.USER:
                 user = self.return_type(option, self.data.resolved.members)
                 user.set_user_data(
                     self.return_type(option, self.data.resolved.users)
                 )
                 option.value = user
 
-            elif option.type is AppCommandOptionType.CHANNEL:
+            elif option.type == AppCommandOptionType.CHANNEL:
                 option.value = self.return_type(
                     option, self.data.resolved.channels
                 )
 
-            elif option.type is AppCommandOptionType.ROLE:
+            elif option.type == AppCommandOptionType.ROLE:
                 option.value = self.return_type(
                     option, self.data.resolved.roles
                 )
 
-            elif option.type is AppCommandOptionType.MENTIONABLE:
+            elif option.type == AppCommandOptionType.MENTIONABLE:
                 user = self.return_type(option, self.data.resolved.members)
                 if user:
                     user.set_user_data(self.return_type(


### PR DESCRIPTION
was not working and everything was str
also bool("False") will return True because the string is not empty

### Changes

-   `improvements`: now a parameter with type int will return an int, not str

 ### Check off the following

-   [x] I have tested my changes with the current requirements
-   [x] My Code follows the pep8 code style.
